### PR TITLE
feat(cli): confirm major-version jumps in `mops self update`

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## 3.0.0 (unreleased)
 
+- `mops self update` now asks for confirmation before updating across major versions, since a new major contains breaking changes. It prints the release-notes link, prompts in a terminal, and in non-interactive environments refuses with an error naming the fix: `mops self update --major`. Updates within the same major are unchanged.
+
 - **Breaking**: mops no longer invokes `dfx` for anything it does itself. `dfx` does not need to be installed.
   - The `dfx` and `dfx-pocket-ic` replicas are gone, and so is the `--replica` flag on `mops test` and `mops bench`. `mops test --mode replica`, `mops bench` and `mops watch --test` always run on PocketIC. Migration: drop `--replica dfx` / `--replica pocket-ic` from your commands; there is nothing to replace them with. Both were deprecated with a warning since 2.14.
   - The dfx-bundled `moc` fallback is gone. `mops build`, `check`, `check-stable`, `test`, `bench`, `docs`, `generate`, `sync` and `mops watch` resolve the compiler only from `[toolchain] moc`, and error naming the fix when it is unset instead of shelling out to `dfx cache show`. `mops toolchain bin --fallback` is removed (the flag, not the command). Migration: run `mops toolchain use moc <version>` once and commit `mops.toml`.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 3.0.0 (unreleased)
 
-- `mops self update` now asks for confirmation before updating across major versions, since a new major contains breaking changes. It prints the release-notes link, prompts in a terminal, and in non-interactive environments refuses with an error naming the fix: `mops self update --major`. Updates within the same major are unchanged.
+- `mops self update` no longer crosses major versions on its own, since a new major contains breaking changes. It prints the release-notes link and asks for confirmation in a terminal; in non-interactive environments it skips the update with a notice and exits successfully, so scripted updates keep working and stay on their major. Pass `--major` to update across majors. Updates within the same major are unchanged.
 
 - **Breaking**: mops no longer invokes `dfx` for anything it does itself. `dfx` does not need to be installed.
   - The `dfx` and `dfx-pocket-ic` replicas are gone, and so is the `--replica` flag on `mops test` and `mops bench`. `mops test --mode replica`, `mops bench` and `mops watch --test` always run on PocketIC. Migration: drop `--replica dfx` / `--replica pocket-ic` from your commands; there is nothing to replace them with. Both were deprecated with a warning since 2.14.

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -955,8 +955,12 @@ const selfCommand = new Command("self").description("Mops CLI management");
 selfCommand
   .command("update")
   .description("Update mops CLI to the latest version")
-  .action(async () => {
-    await self.update();
+  .option(
+    "--major",
+    "Allow updating across major versions without confirmation (major releases contain breaking changes)",
+  )
+  .action(async (options: { major?: boolean }) => {
+    await self.update(options);
   });
 
 selfCommand

--- a/cli/commands/self.ts
+++ b/cli/commands/self.ts
@@ -45,12 +45,14 @@ async function confirmMajorUpdate(latest: string): Promise<boolean> {
     `https://github.com/caffeinelabs/mops/releases/tag/cli-v${latest}`,
   );
 
+  // Not an error: a script running `mops self update` must keep succeeding
+  // (and staying on its major) after the new major ships, not turn red until
+  // someone edits it.
   if (!process.stdout.isTTY) {
-    console.error(
-      chalk.red("Error: ") +
-        `updating across major versions requires confirmation. Run ${chalk.green("mops self update --major")} to update.`,
+    console.log(
+      `Skipping the major update. Run ${chalk.green("mops self update --major")} to update.`,
     );
-    process.exit(1);
+    return false;
   }
 
   let { confirm } = await prompts(
@@ -91,7 +93,6 @@ export async function update({ major = false } = {}) {
     console.log("Current version: " + chalk.yellow(current));
 
     if (kind === "major" && !major && !(await confirmMajorUpdate(latest))) {
-      console.log("aborted");
       return;
     }
 

--- a/cli/commands/self.ts
+++ b/cli/commands/self.ts
@@ -3,6 +3,8 @@ import child_process, { execSync } from "node:child_process";
 import chalk from "chalk";
 import { version, globalConfigDir } from "../mops.js";
 import { cleanCache } from "../cache.js";
+import { classifySelfUpdate } from "../helpers/self-update-kind.js";
+import prompts from "prompts";
 
 let url = "https://x344g-ziaaa-aaaap-abl7a-cai.icp0.io";
 
@@ -31,14 +33,68 @@ export async function getLatestVersion() {
   return (await res.text()).trim();
 }
 
-export async function update() {
+// A new major means breaking changes, so crossing one is a decision, not a
+// routine refresh — confirmed in a terminal, `--major` everywhere else.
+async function confirmMajorUpdate(latest: string): Promise<boolean> {
+  console.log(
+    chalk.yellow(
+      `Version ${latest} is a new major release with breaking changes:`,
+    ),
+  );
+  console.log(
+    `https://github.com/caffeinelabs/mops/releases/tag/cli-v${latest}`,
+  );
+
+  if (!process.stdout.isTTY) {
+    console.error(
+      chalk.red("Error: ") +
+        `updating across major versions requires confirmation. Run ${chalk.green("mops self update --major")} to update.`,
+    );
+    process.exit(1);
+  }
+
+  let { confirm } = await prompts(
+    {
+      type: "confirm",
+      name: "confirm",
+      message: `Update to ${latest}?`,
+      initial: false,
+    },
+    {
+      onCancel() {
+        console.log("aborted");
+        process.exit(0);
+      },
+    },
+  );
+  return confirm;
+}
+
+export async function update({ major = false } = {}) {
   let latest = await getLatestVersion();
   let current = version();
+  let kind = classifySelfUpdate(current, latest);
 
-  if (latest === current) {
+  if (kind === "up-to-date") {
     console.log(chalk.green("You are up to date. Version: " + current));
   } else {
+    // An unparseable tag means the release server is serving something
+    // broken — refuse rather than npm-install whatever it said.
+    if (kind === "invalid") {
+      console.error(
+        chalk.red("Error: ") +
+          `expected a version from ${url}/tags/latest, got ${JSON.stringify(latest)}.`,
+      );
+      process.exit(1);
+    }
+
     console.log("Current version: " + chalk.yellow(current));
+
+    if (kind === "major" && !major && !(await confirmMajorUpdate(latest))) {
+      console.log("aborted");
+      return;
+    }
+
     console.log("Updating to version: " + chalk.green(latest));
 
     let pm = detectPackageManager();

--- a/cli/helpers/self-update-kind.ts
+++ b/cli/helpers/self-update-kind.ts
@@ -1,0 +1,20 @@
+import semver from "semver";
+
+export type SelfUpdateKind = "up-to-date" | "same-major" | "major" | "invalid";
+
+// A new major means breaking changes, so `mops self update` treats crossing
+// one as a decision to confirm, not a routine refresh.
+export function classifySelfUpdate(
+  current: string,
+  latest: string,
+): SelfUpdateKind {
+  if (latest === current) {
+    return "up-to-date";
+  }
+  if (!semver.valid(latest)) {
+    return "invalid";
+  }
+  return semver.major(latest) === semver.major(current)
+    ? "same-major"
+    : "major";
+}

--- a/cli/jest.config.js
+++ b/cli/jest.config.js
@@ -7,6 +7,11 @@ export default {
     "<rootDir>/bundle/",
     "<rootDir>/commands/"
   ],
+  // Source files import each other with .js suffixes (ESM), which jest cannot
+  // resolve back to the .ts sources without this mapping.
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { useESM: true }],
   },

--- a/cli/tests/self-update.test.ts
+++ b/cli/tests/self-update.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "@jest/globals";
+import { classifySelfUpdate } from "../helpers/self-update-kind.js";
+
+// The network fetch and the npm install around this are not testable here;
+// the decision table is, and it is what gates the major-update confirmation.
+describe("classifySelfUpdate", () => {
+  test("identical versions are up to date", () => {
+    expect(classifySelfUpdate("2.20.0", "2.20.0")).toBe("up-to-date");
+  });
+
+  test("minor and patch updates stay in the same major", () => {
+    expect(classifySelfUpdate("2.20.0", "2.21.0")).toBe("same-major");
+    expect(classifySelfUpdate("2.20.0", "2.20.1")).toBe("same-major");
+  });
+
+  test("a new major requires confirmation", () => {
+    expect(classifySelfUpdate("2.20.0", "3.0.0")).toBe("major");
+  });
+
+  test("a major downgrade also requires confirmation", () => {
+    expect(classifySelfUpdate("3.0.0", "2.20.0")).toBe("major");
+  });
+
+  test("a prerelease of the next major counts as a major", () => {
+    expect(classifySelfUpdate("2.20.0", "3.0.0-beta.1")).toBe("major");
+  });
+
+  test("prerelease to release of the same major does not prompt", () => {
+    expect(classifySelfUpdate("3.0.0-beta.1", "3.0.0")).toBe("same-major");
+  });
+
+  test("a non-version tag is rejected", () => {
+    expect(classifySelfUpdate("2.20.0", "")).toBe("invalid");
+    expect(classifySelfUpdate("2.20.0", "<html>error</html>")).toBe("invalid");
+    expect(classifySelfUpdate("2.20.0", "latest")).toBe("invalid");
+  });
+});

--- a/docs/docs/cli/6-self/01-mops-self-update.md
+++ b/docs/docs/cli/6-self/01-mops-self-update.md
@@ -10,3 +10,15 @@ Update the Mops CLI to the latest version.
 ```
 mops self update
 ```
+
+When the latest version is a new **major** release, it contains breaking changes, so `mops self update` asks for confirmation and links the release notes instead of updating right away.
+
+## `--major`
+
+Skip the confirmation and update across major versions. This is also the only way to cross a major non-interactively — in CI or any other non-terminal environment, `mops self update` refuses a major update unless `--major` is passed:
+
+```
+mops self update --major
+```
+
+Updates within the same major (new minor or patch versions) never prompt.

--- a/docs/docs/cli/6-self/01-mops-self-update.md
+++ b/docs/docs/cli/6-self/01-mops-self-update.md
@@ -15,7 +15,7 @@ When the latest version is a new **major** release, it contains breaking changes
 
 ## `--major`
 
-Skip the confirmation and update across major versions. This is also the only way to cross a major non-interactively — in CI or any other non-terminal environment, `mops self update` refuses a major update unless `--major` is passed:
+Skip the confirmation and update across major versions. This is also the only way to cross a major non-interactively — in a non-terminal environment (CI, scripts), `mops self update` prints the notice and exits successfully **without updating** unless `--major` is passed, so a scripted update never absorbs a major silently and never starts failing when one is released:
 
 ```
 mops self update --major


### PR DESCRIPTION
Same guard as [#696](https://github.com/caffeinelabs/mops/pull/696), on the v3 line: a major jump in `mops self update` prints the release-notes link and asks for confirmation; non-interactive environments skip the update with a notice and exit 0 (erroring would break scripted updates the day a major ships), naming `mops self update --major`; an unparseable `/tags/latest` body is an error instead of an npm install spec. Same-major updates are unchanged.

#696 is what partially protects the 2.x→3.0 jump (client-side check, so only users who update into it get it). This one covers 3.x→4.x permanently.

Decision table in `helpers/self-update-kind.ts` with unit tests for the prerelease edges — `2.20.0 → 3.0.0-beta.1` prompts, `3.0.0-beta.1 → 3.0.0` does not, which matters while previews ship from this branch. Full v3 suite passes (26 suites, 265 tests, 75 snapshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
