### PR TITLE
docs: pre-GA sweep — strike done v3 items, fix stale CLI guides

### DIFF
--- a/NEXT-MAJOR.md
+++ b/NEXT-MAJOR.md
@@ -31,8 +31,8 @@ All three shipped in GH #679 (`fix(cli): use real semver in the resolver and alw
 - ~~Verify integrity at **download time**, stop re-hashing `.mops/` on every install; move on-disk verification behind `mops verify`~~ — **done on `v3`**. Files are hashed as they arrive and compared against the registry before the package is committed to the cache; `mops verify` is the on-demand on-disk audit. (GH #517)
 - ~~Add `--locked`; drop the `CI` env-var auto-detection~~ — **done on `v3`** (GH #516). Available on `mops install` and every implicitly-resolving command; `mops sources` deliberately has none (dfx packtool parses its stdout mid-build). **Design correction:** `--locked` does *not* re-walk the dependency graph to byte-compare a freshly computed lock. It cannot: a lock-driven install skips the versions that lost a conflict, so their manifests are never cached and `resolvePackages({skipLock: true})` throws ENOENT on a fresh clone (reproduced). Instead it checks that the lock is present, parseable, current-format, pins every dependency declared in `mops.toml`, and agrees with the registry on every file hash. Same structural limitation the resolver-correctness work hit (GH #679); closing it needs a per-candidate manifest fetch, which is a new feature, not a lockfile change.
 - ~~**Drop `--lock <check|update|ignore>` entirely**~~ — **done on `v3`**. `check` → `--locked`; `ignore` → no successor; `update` → plain `mops install`, now self-healing (also migrates locks carrying absolute local `path` entries, which previously required an explicit `--lock update`).
-- `mops install` becomes purely additive (`npm install` semantics) — no implicit "switch to check mode".
-- `mops.lock` enabled by default (already done in 2.8); remove opt-in/legacy paths — and with `--lock ignore` gone, no opt-out at all (cargo model; ties into the commit-guidance question under Decide before release). (GH #288)
+- ~~`mops install` becomes purely additive (`npm install` semantics) — no implicit "switch to check mode".~~ — **done on `v3`** with the `--locked` work (GH #516): the `CI` env auto-`check` path is gone; plain commands maintain the lock, `--locked` is the only check mode and always explicit.
+- ~~`mops.lock` enabled by default (already done in 2.8); remove opt-in/legacy paths — and with `--lock ignore` gone, no opt-out at all.~~ — **done on `v3`**: the only lock modes left are `locked`/`maintain`/`skip` (`skip` is internal to `mops sources`); no user-facing opt-out exists. (GH #288)
 
 ### Hidden-state cleanup (silent-wrong-behavior — high priority)
 
@@ -100,7 +100,7 @@ Everything here except the canister-id item shipped in GH #676 (`feat(cli)!: str
 ### Decide before release
 
 - ~~Lockfile commit guidance~~ — **decided and done on `v3`**: everyone commits `mops.lock`, libraries included. A library's lock has no effect on consumers (they resolve their own graph) and it makes the library's own CI reproducible. The `mops.lock created.` message, `docs/docs/10-mops.lock.md` and the CLI skill all say so now.
-- Custom registry endpoints — ship as supported feature or drop the env-var? Removal is only free in a major. (LIN, PR #425)
+- ~~Custom registry endpoints — ship as supported feature or drop the env-var?~~ — **decided: keep as supported.** `MOPS_REGISTRY_HOST` / `MOPS_REGISTRY_CANISTER_ID` are documented in the 3.x env-vars page, and the `@icp-sdk/core` 5.x entry in the changelog names their compatibility requirement (the replica must serve the HTTP API `v3` endpoint). (LIN, PR #425)
 
 ---
 
@@ -147,7 +147,7 @@ v3 tells users mops does not support `dfx`, so this can no longer lag behind —
 - ~~`.github/workflows/release.yml`: replace `dfinity/setup-dfx` with the `icp` setup action.~~ Done — both canister deploys go through `.github/actions/deploy-canister`.
 - ~~`.github/workflows/{mops-test,setup-mops}.yml` still install dfx.~~ Done — `mops.toml` pins `[toolchain] pocket-ic`, which 2.x honours over the dfx replica, and `setup-mops.yml` dropped its 2024-era `mops-version: 1.0.0` pin. 1.0.0 was the only version a pin could not rescue: it speaks only the PocketIC 4.0.0 API.
 - `cli/tests/build/no-dfx/` + `build-no-dfx.test.ts` — keep as a regression test that mops works with neither `dfx` nor `icp` on PATH.
-- `cli/{DEVELOPMENT,RELEASE}.md`, blog posts — rewrite in `icp` terms; add a "migrating from dfx" note. (`cli/README.md`, `docs/docs/01-quick-start.md`, `backend/DEVELOPMENT.md` and the root `DEVELOPMENT.md` are done.)
+- ~~`cli/{DEVELOPMENT,RELEASE}.md` — rewrite in `icp` terms.~~ Done — `cli/DEVELOPMENT.md` is a real development doc (the release half was stale duplication of `RELEASE.md`, down to a dead `dfx deploy`), and `cli/RELEASE.md` deploys with the npm scripts and documents the preview-tag path. Remaining: a release blog post announcing v3 with a migrating-from-dfx note.
 
 ---
 

--- a/cli/DEVELOPMENT.md
+++ b/cli/DEVELOPMENT.md
@@ -1,65 +1,53 @@
-# Mops CLI
+# Mops CLI development
+
+Releasing is a separate document: [RELEASE.md](RELEASE.md).
 
 ## Prerequisites
 
-On macOS, you need to install `gnu-tar` package:
-```
-brew install gnu-tar
-```
+- Node.js >= 20 and npm
+- [bun](https://bun.sh) — `npm run build` bundles with `bun build`
+- GNU tar, on macOS only (`bundle:tar` builds the reproducible tarball with `tar --sort name`, which BSD tar lacks):
 
-To make it available in your shell as `tar`, add the following to your `~/.zshrc` or `~/.bashrc`:
-```
-export PATH="$HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin:$PATH"
-```
+  ```
+  brew install gnu-tar
+  ```
 
-## Steps
+  To make it available in your shell as `tar`, add the following to your `~/.zshrc` or `~/.bashrc`:
 
-1. Run `bun install`
+  ```
+  export PATH="$HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin:$PATH"
+  ```
 
-2. Update changelog in `CHANGELOG.md` file
+## Dev loop
 
-3. Push latest commits to `main` branch
-
-4. Check reproducibility of the build (see below)
-
-5. Update the version in `package.json` using `npm version` command
-
-6. Publish
-
-## Publish to npm
-```
-npm publish
+```bash
+cd cli
+npm ci
+npm run check           # tsc --noEmit
+npm test                # Jest (all tests)
+npm test -- build.test.ts                    # single test file
+npm test -- --testNamePattern="pattern"      # filter by test name
+npm run build           # TypeScript compile + bundle
 ```
 
-## Check reproducibility of the build
+To run your working copy against a project, use the repo-root helper — it runs the CLI from source via `tsx`:
 
-Check release hash of latest build for version `0.0.0` at https://github.com/caffeinelabs/mops/actions/workflows/build-hash.yml
-
-Build locally version `0.0.0`
-```
-MOPS_VERSION=0.0.0 ./build.sh
+```bash
+npm run mops -- install
 ```
 
-Compare hashes.
+## Reproducible build
 
-## Publish on-chain
-_Run from root of the project_
+Every release's bundle hash is published by the [build-hash workflow](https://github.com/caffeinelabs/mops/actions/workflows/build-hash.yml). To reproduce a build locally (requires Docker; the builder base image lives in [`cli-builder/`](../cli-builder/)):
 
-1. Make sure Docker is running
-
-2. Prepeare release
-```
-npm run release-cli
+```bash
+cd cli
+MOPS_VERSION=<version> COMMIT_HASH=<commit_hash> ./build.sh
 ```
 
-3. Deploy canister
-```
-dfx deploy --network ic --no-wallet cli --identity mops
-```
+To verify a released bundle against its published hash:
 
-## Verify build
-
-```
+```bash
 docker build . --build-arg COMMIT_HASH=<commit_hash> --build-arg MOPS_VERSION=<mops_version> -t mops
 docker run --rm --env SHASUM=<build_hash> mops
 ```

--- a/cli/RELEASE.md
+++ b/cli/RELEASE.md
@@ -13,8 +13,24 @@ The [`release-pr.yml`](../.github/workflows/release-pr.yml) workflow validates t
 > **Note:** This pipeline only deploys the `cli` and `docs` canisters. The `main`, `assets`, `blog`, and `play-frontend` canisters require a manual deploy. If a release includes changes to any of those (e.g. `backend/main/` or `frontend/`), upgrade them manually (staging first, then `ic`):
 >
 > ```bash
-> NODE_ENV=production dfx deploy --no-wallet --identity mops --network <staging|ic> <canister>
+> npm run deploy-staging <canister>
+> npm run deploy-ic <canister>
 > ```
+>
+> See the root [DEVELOPMENT.md](../DEVELOPMENT.md) for how deploys and canister IDs work.
+
+## Preview releases (3.x betas)
+
+Previews are cut by tagging manually — `prepare-cli-release` has no prerelease option:
+
+```bash
+git tag cli-vX.Y.Z-beta.N <commit-on-v3>
+git push origin cli-vX.Y.Z-beta.N
+```
+
+`release.yml` detects the prerelease by parsing the version (any prerelease component counts, not a tag pattern) and deviates from a stable release in exactly these ways: npm publish lands under the `next` dist-tag instead of `latest`, the GitHub Release is marked prerelease, and nothing is uploaded to the `cli` canister — so `mops self update` and fresh `install.sh` installs keep serving the latest stable, and no artifacts PR is created. The docs canister still deploys (previews are what publish `docs.mops.one/next/`).
+
+Install a preview with `npm i -g ic-mops@next` or a pinned `ic-mops@X.Y.Z-beta.N`.
 
 ## Artifacts PR
 


### PR DESCRIPTION
Housekeeping from the pre-GA audit. Three files, no code.

**NEXT-MAJOR.md** — two lockfile bullets shipped with the `--locked` work (#516) but were never struck; struck now with what actually shipped. The "decide before release" custom-registry question is recorded as decided: **keep as supported** — `MOPS_REGISTRY_HOST` / `MOPS_REGISTRY_CANISTER_ID` are already documented in the 3.x env-vars page, so dropping them would now be the breaking change. With this, the only remaining unstruck items in committed scope are non-gating (GH #274, the release blog post, upstream-gated #651/#655).

**cli/DEVELOPMENT.md** — was an old release doc wearing the wrong name: "Publish to npm", "Publish on-chain", ending in a `dfx deploy --network ic` that no longer exists (`dfx.json` is deleted; the pipeline owns deploys). Rewritten as an actual development doc: prerequisites with the reason each exists (gnu-tar is for `bundle:tar`'s `--sort name`), the dev loop, and reproducible-build verification pointing at `build.sh`.

**cli/RELEASE.md** — the manual-deploy fallback still ran `dfx deploy`; now `npm run deploy-staging <canister>` / `deploy-ic <canister>`. Adds a **Preview releases** section, since that's how every 3.0.0 beta ships and it was documented nowhere: manual tag, and the exact set of deviations from a stable release (npm `next` dist-tag, GitHub prerelease, no `cli` canister upload so `mops self update` keeps serving stable, docs still deploy — previews are what publish `/next/`).

## Left alone deliberately

`cli-builder/` still points at the `zenvoich/mops-builder` Docker Hub image. The `cli/Dockerfile` pins it by sha256 digest, so reproducible-build verification doesn't trust the registry — but the image is owned by an account nobody here controls, so it can't be updated, only replaced. Moving to a caffeinelabs-owned image is infra work, not docs; flagging it as an open decision rather than half-doing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)