### PR TITLE
ci: stop deploying the docs canister from main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,21 +211,20 @@ jobs:
           done
           exit 1
 
-      - name: Install docs dependencies
-        working-directory: docs
-        run: npm ci
-
-      - name: Deploy docs canister
-        env:
-          DFX_WARNING: -mainnet_plaintext_identity
-        run: |
-          for i in 1 2 3; do
-            dfx deploy --network ic --no-wallet docs --identity mops && exit 0
-            echo "::warning::Docs canister deploy attempt $i/3 failed"
-            [ "$i" -lt 3 ] && sleep 30
-          done
-          exit 1
-
+      # No docs deploy here: the `v3` branch owns the docs canister, and that
+      # covers the 2.x docs too. Its Docusaurus build is a superset of this
+      # branch's — the same `docs/versioned_docs/version-2.x/` at the site root,
+      # plus the in-development line under /next — so a 2.x release publishing
+      # docs from here would add nothing and drop /next until v3 redeployed.
+      #
+      # It would also fail. v3 migrated the docs canister to dfinity's
+      # certified-assets canister (`@dfinity/static-site` in `icp.yaml`), which
+      # `dfx deploy` cannot drive: different wasm, different Candid interface.
+      #
+      # So docs changes on this branch reach docs.mops.one only once they are
+      # merged into v3 and v3 deploys. Publish them with, from a v3 checkout:
+      #   icp deploy docs -e ic --identity mops --no-create --yes
+      #
       # --- Commit release artifacts ---
 
       - name: Create GitHub App Token

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -48,8 +48,9 @@ const config = {
 					sidebarPath: './sidebars.js',
 					// The released line is served at the root; the in-development line
 					// lives under /next. Flip back to 'current' at the 3.0.0 GA.
-					// Both branches must agree: the docs canister is shared, so
-					// whichever branch deployed most recently decides the layout.
+					// Keep this in step with `v3`, which is the only branch that
+					// deploys the docs canister — this config shapes local previews
+					// here, but what docs.mops.one serves is built from v3.
 					lastVersion: '2.x',
 					versions: {
 						current: {label: '3.x (unreleased)', path: 'next'},


### PR DESCRIPTION
Companion to #708, which migrates the docs canister on `v3` to dfinity's certified-assets canister. Merge this one first, or alongside.

## Why

`v3` owns the docs canister from now on, and that covers the **2.x docs too**. v3's Docusaurus build is a superset of this branch's: the same `docs/versioned_docs/version-2.x/` at the site root, plus the in-development line under `/next`. So a 2.x release publishing docs from here adds nothing, and would drop `/next` until v3 redeployed.

After #708 it would also **fail**. That PR moves the canister to `@dfinity/static-site`, and `dfx deploy` cannot drive it — different wasm, different Candid interface. The step would error and abort the release *before* the artifacts PR, i.e. a half-finished release.

## What changed

Removes `Deploy docs canister` and the `Install docs dependencies` step that only fed it, leaving the reasoning and the manual publish command in a comment where they were.

The `cli` canister deploy is deliberately untouched — that canister still runs the legacy asset canister and `dfx deploy` still drives it correctly.

Also refreshes a now-stale comment in `docs/docusaurus.config.js`: it said the two branches must agree because the canister is shared and "whichever branch deployed most recently decides the layout." Only v3 deploys now, so it says that instead. The config still shapes local previews on this branch, so the versions block itself is unchanged.

## Consequence worth knowing

Docs edits made on `main` no longer reach docs.mops.one on a 2.x release. They reach it once merged into `v3` and v3 deploys — which per the plan happens after any main deploy. To publish out of band, from a v3 checkout:

```
icp deploy docs -e ic --identity mops --no-create --yes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRHrmmy3iWFZwPhQtXVfQQ</body>


---
_Generated by [Claude Code](https://claude.ai/code/session_01SRHrmmy3iWFZwPhQtXVfQQ)_