### PR TITLE
fix(cli): survive incomplete global-cache state instead of crashing with ENOENT

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Mops CLI Changelog
 
 ## Next
+- Fix crashes with a raw `ENOENT: no such file or directory ... mops.toml` on incomplete cache state:
+  - `mops add`, `update`, `sync` and `remove` after a lock-driven install used to crash while regenerating the lock. Installing from `mops.lock` deliberately skips versions that lost a dependency conflict, but the re-walk of the dependency graph still read every declared version's manifest from the global cache. Manifests missing from the cache are now downloaded on demand; if the download fails, the command reports which package could not be fetched instead of crashing.
+  - A global cache entry now counts as cached only if it is complete: registry packages must contain `mops.toml`, GitHub packages must be non-empty. Leftover empty directories from interrupted runs (or a bad shared cache volume) are deleted and re-downloaded instead of being treated as cache hits.
+  - Packages missing from the global cache are re-downloaded when syncing `.mops`, instead of failing the copy.
+  - Toolchain requirements checks (`moc`/`lintoko` minimum versions) no longer crash when a package manifest is missing from `.mops`; they fall back to the global cache copy or skip that package, since these checks are advisory.
+  - Uncached GitHub dependencies encountered while resolving the dependency graph are now fetched, so their transitive dependencies are no longer silently dropped from resolution.
 
 ## 2.21.0
 - Security: GitHub dependencies (`repo = "..."`) are now extracted with a purpose-built unzipper instead of the `decompress` package, which has two unfixed advisories ([GHSA-mp2f-45pm-3cg9](https://github.com/advisories/GHSA-mp2f-45pm-3cg9), [GHSA-h39j-r5qq-r9mm](https://github.com/advisories/GHSA-h39j-r5qq-r9mm)) allowing a malicious archive to write files outside the install directory. Entries that would escape the target directory now fail the whole extraction, and symlinks are written as plain files instead of being created. `npm audit` on the CLI is clean again. One behavior change: a GitHub dependency whose repo contains symlinks gets those as regular files holding the link target.

--- a/cli/cache.ts
+++ b/cli/cache.ts
@@ -94,9 +94,23 @@ export let getDepCacheDir = (cacheName: string) => {
   return path.join(getGlobalCacheDir(), "packages", cacheName);
 };
 
+// Staged writes commit via atomic rename, so a present dir is normally a
+// complete package. Empty or manifest-less dirs are leftovers from
+// interrupted pre-staging runs (or a bad shared volume) — treat them as a
+// miss and remove them so the caller re-downloads.
 export let isDepCached = (cacheName: string) => {
   let dir = getDepCacheDir(cacheName);
-  return fs.existsSync(dir);
+  if (!fs.existsSync(dir)) {
+    return false;
+  }
+  let complete = cacheName.startsWith("_github/")
+    ? fs.readdirSync(dir).length > 0
+    : fs.existsSync(path.join(dir, "mops.toml"));
+  if (!complete) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    return false;
+  }
+  return true;
 };
 
 export function getDepCacheName(name: string, version: string) {

--- a/cli/check-requirements.ts
+++ b/cli/check-requirements.ts
@@ -1,7 +1,9 @@
 import path from "node:path";
+import { existsSync } from "node:fs";
 import { SemVer } from "semver";
 import chalk from "chalk";
 
+import { getDepCacheDir } from "./cache.js";
 import { getDependencyType, getRootDir, readConfig } from "./mops.js";
 import { resolvePackages } from "./resolve-packages.js";
 import { getMocSemVer } from "./helpers/get-moc-version.js";
@@ -35,9 +37,16 @@ export async function checkRequirements({ verbose = false } = {}) {
     for (let [name, version] of Object.entries(resolvedPackages)) {
       if (getDependencyType(version) === "mops") {
         let pkgId = getPackageId(name, version);
-        let depConfig = readConfig(
-          path.join(rootDir, ".mops", pkgId, "mops.toml"),
-        );
+        // requirements checks are advisory — fall back to the global cache
+        // and skip the package instead of crashing on a missing manifest
+        let configPath = path.join(rootDir, ".mops", pkgId, "mops.toml");
+        if (!existsSync(configPath)) {
+          configPath = path.join(getDepCacheDir(pkgId), "mops.toml");
+          if (!existsSync(configPath)) {
+            continue;
+          }
+        }
+        let depConfig = readConfig(configPath);
         let required = depConfig.requirements?.[tool];
 
         if (required) {

--- a/cli/commands/install/sync-local-cache.ts
+++ b/cli/commands/install/sync-local-cache.ts
@@ -3,10 +3,13 @@ import path from "node:path";
 import {
   copyCache,
   getDepCacheName,
+  isDepCached,
   sweepStaleStagingDirs,
 } from "../../cache.js";
 import { getDependencyType, getRootDir } from "../../mops.js";
 import { resolvePackages } from "../../resolve-packages.js";
+import { installFromGithub } from "../../vessel.js";
+import { installMopsDep } from "./install-mops-dep.js";
 
 export async function syncLocalCache({ verbose = false } = {}): Promise<
   Record<string, string>
@@ -21,7 +24,7 @@ export async function syncLocalCache({ verbose = false } = {}): Promise<
   let installedDeps: Record<string, string> = {};
 
   await Promise.all(
-    Object.entries(resolvedPackages).map(([name, value]) => {
+    Object.entries(resolvedPackages).map(async ([name, value]) => {
       let depType = getDependencyType(value);
 
       if (depType === "mops" || depType === "github") {
@@ -32,14 +35,32 @@ export async function syncLocalCache({ verbose = false } = {}): Promise<
           if (depType === "mops") {
             installedDeps[name] = value;
           }
-          return copyCache(cacheName, path.join(rootDir, ".mops", cacheName));
+          // a resolved package can be missing from the global cache
+          // (pruned cache, interrupted install) — restore it before copying
+          if (!isDepCached(cacheName)) {
+            let ok =
+              depType === "mops"
+                ? await installMopsDep(name, value, {
+                    silent: true,
+                    ignoreTransitive: true,
+                  })
+                : await installFromGithub(name, value, {
+                    silent: true,
+                    ignoreTransitive: true,
+                  });
+            if (!ok) {
+              throw Error(
+                `Package ${name} = "${value}" is not in the cache and could not be downloaded`,
+              );
+            }
+          }
+          await copyCache(cacheName, dest);
         }
       }
-
-      return Promise.resolve();
     }),
-  ).catch((errors) => {
-    throw errors?.[0];
+  ).catch((err) => {
+    // ncp rejects with an array of errors
+    throw Array.isArray(err) ? err[0] : err;
   });
 
   return installedDeps;

--- a/cli/resolve-packages.ts
+++ b/cli/resolve-packages.ts
@@ -8,9 +8,10 @@ import {
   parseGithubURL,
   readConfig,
 } from "./mops.js";
-import { VesselConfig, readVesselConfig } from "./vessel.js";
+import { VesselConfig, installFromGithub, readVesselConfig } from "./vessel.js";
 import { Config, Dependency } from "./types.js";
-import { getDepCacheDir, getDepCacheName } from "./cache.js";
+import { getDepCacheDir, getDepCacheName, isDepCached } from "./cache.js";
+import { installMopsDep } from "./commands/install/install-mops-dep.js";
 import { getPackageId } from "./helpers/get-package-id.js";
 import { normalizeLocalDepPath } from "./helpers/normalize-local-path.js";
 import { checkLockFileLight, readLockFile } from "./integrity.js";
@@ -127,6 +128,14 @@ export async function resolvePackages({
       // read nested config
       if (repo) {
         let cacheDir = getDepCacheName(name, repo);
+        if (!isDepCached(cacheDir)) {
+          // best effort: an uncached github dep would otherwise silently
+          // drop its nested deps from resolution
+          await installFromGithub(name, repo, {
+            silent: true,
+            ignoreTransitive: true,
+          });
+        }
         nestedConfig =
           (await readVesselConfig(getDepCacheDir(cacheDir), {
             silent: true,
@@ -141,6 +150,22 @@ export async function resolvePackages({
         }
       } else if (version) {
         let cacheDir = getDepCacheName(name, version);
+        // a lock-driven install only caches winning versions, so a later
+        // re-walk (stale lock after add/update/sync) can hit versions
+        // absent from the cache — fetch them instead of crashing
+        if (!isDepCached(cacheDir)) {
+          let ok = await installMopsDep(name, version, {
+            silent: true,
+            ignoreTransitive: true,
+          });
+          if (!ok) {
+            console.error(
+              chalk.red("Error: ") +
+                `Package ${name}@${version} is not in the cache and could not be downloaded`,
+            );
+            process.exit(1);
+          }
+        }
         nestedConfig = readConfig(
           path.join(getDepCacheDir(cacheDir), "mops.toml"),
         );

--- a/cli/tests/cache-resilience.test.ts
+++ b/cli/tests/cache-resilience.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { cli, useTempFixtures } from "./helpers";
+
+// Regressions for crashes on incomplete global-cache state (raw ENOENT on
+// `<cache>/packages/<pkg>@<ver>/mops.toml`): a lock-driven install caches
+// only winning versions, so a later stale-lock re-walk used to crash on
+// versions that lost a conflict; and an empty cache dir used to count as a
+// cache hit.
+describe("global cache resilience", () => {
+  jest.setTimeout(300_000);
+
+  const makeTempFixture = useTempFixtures(
+    path.join(import.meta.dirname, "install"),
+  );
+
+  const makeTempCacheHome = async () =>
+    await mkdtemp(path.join(os.tmpdir(), "mops-cache-"));
+
+  test("add after a lock-driven install fetches conflict losers instead of crashing", async () => {
+    const cwd = await makeTempFixture("conflict-loser");
+    const cacheHome = await makeTempCacheHome();
+    const env = { CI: undefined, XDG_CACHE_HOME: cacheHome };
+    const packagesDir = path.join(cacheHome, "mops", "packages");
+
+    try {
+      // full install populates the cache with every declared version
+      // (winner core@1.0.0 and loser core@2.6.1) and writes mops.lock
+      const first = await cli(["install"], { cwd, env });
+      expect(first.exitCode).toBe(0);
+      expect(existsSync(path.join(cwd, "mops.lock"))).toBe(true);
+
+      // fresh machine: the committed lock survives, caches don't
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+      rmSync(cacheHome, { recursive: true, force: true });
+
+      // lock-driven install caches only the winning versions
+      const second = await cli(["install"], { cwd, env });
+      expect(second.exitCode).toBe(0);
+      expect(existsSync(path.join(packagesDir, "core@1.0.0"))).toBe(true);
+      expect(existsSync(path.join(packagesDir, "core@2.6.1"))).toBe(false);
+
+      // the stale-lock re-walk visits the losing version's manifest;
+      // it must be fetched on demand, not crash with ENOENT
+      const result = await cli(["add", "base@0.16.0"], { cwd, env });
+      expect(result.stderr).not.toMatch(/ENOENT/);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/Package installed/);
+      expect(
+        existsSync(path.join(packagesDir, "core@2.6.1", "mops.toml")),
+      ).toBe(true);
+    } finally {
+      rmSync(cacheHome, { recursive: true, force: true });
+    }
+  });
+
+  test("empty global cache dir counts as a miss and is re-downloaded", async () => {
+    const cwd = await makeTempFixture("success");
+    const cacheHome = await makeTempCacheHome();
+    const env = { CI: undefined, XDG_CACHE_HOME: cacheHome };
+    const coreDir = path.join(cacheHome, "mops", "packages", "core@1.0.0");
+
+    try {
+      rmSync(path.join(cwd, "mops.lock"), { force: true });
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+
+      // interrupted-run leftover: the dir exists but holds no package
+      mkdirSync(coreDir, { recursive: true });
+
+      const result = await cli(["install"], { cwd, env });
+      expect(result.stderr).not.toMatch(/ENOENT/);
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(path.join(coreDir, "mops.toml"))).toBe(true);
+    } finally {
+      rmSync(cacheHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/tests/install/conflict-loser/lib/mops.toml
+++ b/cli/tests/install/conflict-loser/lib/mops.toml
@@ -1,0 +1,6 @@
+[package]
+name = "lib"
+version = "1.0.0"
+
+[dependencies]
+core = "2.6.1"

--- a/cli/tests/install/conflict-loser/lib/src/lib.mo
+++ b/cli/tests/install/conflict-loser/lib/src/lib.mo
@@ -1,0 +1,3 @@
+module {
+  public let hello = "world";
+};

--- a/cli/tests/install/conflict-loser/mops.toml
+++ b/cli/tests/install/conflict-loser/mops.toml
@@ -1,0 +1,3 @@
+[dependencies]
+core = "1.0.0"
+lib = "./lib"


### PR DESCRIPTION
Commands that regenerate a stale `mops.lock` — `mops add`, `update`, `sync`, `remove` — crashed with a raw Node `ENOENT: no such file or directory ... mops.toml` whenever the project's dependency graph contains version conflicts and the previous install was lock-driven.

Root cause: installing from a valid lock deliberately downloads only the versions that **won** a conflict, but regenerating a stale lock re-walks the graph and reads **every declared version's** manifest from the global cache — including the losers that were never downloaded. Validation (`--locked`) was made walk-free earlier on this line, but regeneration was not, so the first `mops add` after a lock-driven install opened a manifest that could not exist. The crash evaded tests because a plain no-lock `mops install` installs the full graph recursively, so the cache always happened to contain the losers.

The fix makes the cache self-healing at every read site instead of assuming install left the right state on disk:

- **Fetch-on-miss in the graph walk** (`resolve-packages.ts`): a registry manifest missing from the cache is downloaded before it is read; if the download fails the command reports which package could not be fetched. Uncached GitHub deps are also fetched, so their transitive deps are no longer silently dropped from resolution.
- **`isDepCached` requires a complete entry** (`cache.ts`): registry packages must contain `mops.toml`, GitHub packages must be non-empty. Leftover empty dirs from interrupted pre-staging runs (or a bad shared cache volume) are deleted and re-downloaded instead of counting as hits — this also fixes the same ENOENT at `install-mops-dep.ts`'s post-hit manifest read.
- **`.mops` syncing restores missing packages** (`sync-local-cache.ts`): a resolved winner absent from the global cache is downloaded before the copy, and a real error surfaces instead of `throw undefined` (the old catch assumed ncp's array-of-errors shape).
- **Requirements checks are non-fatal** (`check-requirements.ts`): the advisory moc/lintoko minimum-version check falls back to the global-cache manifest and skips the package rather than crashing.

Before (second machine with a committed lock, after `mops install`):

```
$ mops add base@0.16.0
Checking integrity...
Error: ENOENT: no such file or directory, open '~/.cache/mops/packages/core@2.6.1/mops.toml'
```

After:

```
$ mops add base@0.16.0
Package installed base = "0.16.0"
```

Both regression tests were verified to fail with this exact ENOENT signature before the fix. They isolate the global cache via `XDG_CACHE_HOME`, so they don't disturb the developer's real cache.

## What is unchanged

The alternative fix — having `add`/`update`/`sync` reinstall the full graph before regenerating the lock — is intentionally not taken: fetch-on-miss repairs exactly the gap and keeps those commands fast. Conflict-winner resolution, lock format, and `--locked` semantics are untouched; no command-line surface changes, so no docs updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)