### PR TITLE
feat(cli): record the dependency graph in mops.lock

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
+- `mops.lock` is now written atomically (staged temp file + rename), so a concurrent `mops install` can no longer read a half-written lock and crash with `Unexpected end of JSON input`.
 - `mops.lock` now records the declared dependencies of every registry package version in the graph (`graph` section), including versions that lost a conflict. Regenerating a stale lock (`mops add`/`remove`/`update`/`sync`, or after editing `mops.toml`) resolves from these recorded edges instead of reading — and, since the fix below, downloading — manifests of packages that were never installed. Works offline and adds no network calls. Locks written by older CLIs have no `graph` and keep the previous behavior; older CLIs ignore the new field.
 - Fix crashes with a raw `ENOENT: no such file or directory ... mops.toml` on incomplete cache state:
   - `mops add`, `update`, `sync` and `remove` after a lock-driven install used to crash while regenerating the lock. Installing from `mops.lock` deliberately skips versions that lost a dependency conflict, but the re-walk of the dependency graph still read every declared version's manifest from the global cache. Manifests missing from the cache are now downloaded on demand; if the download fails, the command reports which package could not be fetched instead of crashing.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
+- `mops.lock` now records the declared dependencies of every registry package version in the graph (`graph` section), including versions that lost a conflict. Regenerating a stale lock (`mops add`/`remove`/`update`/`sync`, or after editing `mops.toml`) resolves from these recorded edges instead of reading — and, since the fix below, downloading — manifests of packages that were never installed. Works offline and adds no network calls. Locks written by older CLIs have no `graph` and keep the previous behavior; older CLIs ignore the new field.
 - Fix crashes with a raw `ENOENT: no such file or directory ... mops.toml` on incomplete cache state:
   - `mops add`, `update`, `sync` and `remove` after a lock-driven install used to crash while regenerating the lock. Installing from `mops.lock` deliberately skips versions that lost a dependency conflict, but the re-walk of the dependency graph still read every declared version's manifest from the global cache. Manifests missing from the cache are now downloaded on demand; if the download fails, the command reports which package could not be fetched instead of crashing.
   - A global cache entry now counts as cached only if it is complete: registry packages must contain `mops.toml`, GitHub packages must be non-empty. Leftover empty directories from interrupted runs (or a bad shared cache volume) are deleted and re-downloaded instead of being treated as cache hits.

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -5,7 +5,7 @@ import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 import { getDependencyType, getRootDir, readConfig } from "./mops.js";
 import { mainActor } from "./api/actors.js";
-import { resolvePackages } from "./resolve-packages.js";
+import { resolveDepsAndGraph, resolvePackages } from "./resolve-packages.js";
 import { getPackageId } from "./helpers/get-package-id.js";
 import { warnCiLockAutoDetect } from "./helpers/deprecate-ci-lock.js";
 
@@ -30,6 +30,10 @@ type LockFileV3 = {
   mopsTomlDepsHash: string;
   hashes: Record<string, Record<string, string>>;
   deps: Record<string, string>;
+  // declared dependency edges per registry package version (losers included),
+  // so a stale lock can be regenerated without those versions on disk;
+  // optional: locks written by older CLIs don't have it
+  graph?: Record<string, Record<string, string>>;
 };
 
 type LockFile = LockFileV1 | LockFileV2 | LockFileV3;
@@ -162,6 +166,22 @@ export function readLockFile(): LockFile | null {
   return null;
 }
 
+// Declared dependency edges from the lock. Tolerates a missing, corrupt or
+// pre-graph lock (unlike readLockFile, which exits on corruption) — the graph
+// is an optimization and its absence must never block regeneration.
+export function readLockFileGraph(): Record<string, Record<string, string>> {
+  let lockFile = path.join(getRootDir(), "mops.lock");
+  try {
+    let lock = JSON.parse(fs.readFileSync(lockFile).toString());
+    if (lock?.version === 3 && lock.graph) {
+      return lock.graph;
+    }
+  } catch {
+    // fall through
+  }
+  return {};
+}
+
 // check if lock file exists and integrity of mopsTomlDepsHash
 export function checkLockFileLight(): boolean {
   let existingLockFileJson = readLockFile();
@@ -190,7 +210,9 @@ export async function updateLockFile({
   }
 
   // skipLock: re-resolve from mops.toml so abs→relative local paths migrate.
-  let resolvedDeps = await resolvePackages({ skipLock: true });
+  let { deps: resolvedDeps, graph } = await resolveDepsAndGraph({
+    skipLock: true,
+  });
 
   let fileHashes = await getFileHashesFromRegistry();
 
@@ -198,6 +220,7 @@ export async function updateLockFile({
     version: 3,
     mopsTomlDepsHash: getMopsTomlDepsHash(),
     deps: resolvedDeps,
+    graph,
     hashes: fileHashes.reduce(
       (acc, [packageId, fileHashes]) => {
         acc[packageId] = fileHashes.reduce(

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -239,13 +239,28 @@ export async function updateLockFile({
   let rootDir = getRootDir();
   let lockFile = path.join(rootDir, "mops.lock");
   let isNew = !fs.existsSync(lockFile);
-  fs.writeFileSync(lockFile, JSON.stringify(lockFileJson, null, 2));
+  writeLockFileAtomic(lockFile, JSON.stringify(lockFileJson, null, 2));
   if (isNew) {
     console.log("mops.lock created.");
     console.log("  Applications: commit this file.");
     console.log("  Libraries: add mops.lock to .gitignore.");
   }
   return true;
+}
+
+// Stage into a sibling temp file and atomic-rename onto the lock, so a
+// concurrent `mops install` never reads a half-written lock.
+function writeLockFileAtomic(lockFile: string, content: string) {
+  let tmpFile = `${lockFile}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpFile, content);
+  try {
+    fs.renameSync(tmpFile, lockFile);
+  } catch {
+    // Windows can refuse to replace a file another process holds open;
+    // fall back to a direct write rather than failing the command
+    fs.writeFileSync(lockFile, content);
+    fs.rmSync(tmpFile, { force: true });
+  }
 }
 
 // compare hashes of local files with hashes from the lock file

--- a/cli/resolve-packages.ts
+++ b/cli/resolve-packages.ts
@@ -5,6 +5,7 @@ import chalk from "chalk";
 import {
   checkConfigFile,
   getRootDir,
+  parseDepValue,
   parseGithubURL,
   readConfig,
 } from "./mops.js";
@@ -12,26 +13,54 @@ import { VesselConfig, installFromGithub, readVesselConfig } from "./vessel.js";
 import { Config, Dependency } from "./types.js";
 import { getDepCacheDir, getDepCacheName, isDepCached } from "./cache.js";
 import { installMopsDep } from "./commands/install/install-mops-dep.js";
+import { getDepName } from "./helpers/get-dep-name.js";
 import { getPackageId } from "./helpers/get-package-id.js";
 import { normalizeLocalDepPath } from "./helpers/normalize-local-path.js";
-import { checkLockFileLight, readLockFile } from "./integrity.js";
+import {
+  checkLockFileLight,
+  readLockFile,
+  readLockFileGraph,
+} from "./integrity.js";
 
-export async function resolvePackages({
-  conflicts = "ignore" as "warning" | "error" | "ignore",
+type ResolveOptions = {
+  conflicts?: "warning" | "error" | "ignore";
   // Bypass a valid lock so `--lock update` can rewrite absolute local paths.
+  skipLock?: boolean;
+};
+
+export async function resolvePackages(
+  options: ResolveOptions = {},
+): Promise<Record<string, string>> {
+  return (await resolveDepsAndGraph(options)).deps;
+}
+
+// Resolves winners and collects the declared dependency edges of every
+// registry package version visited (losers included), so the lock can be
+// regenerated later without those versions on disk.
+export async function resolveDepsAndGraph({
+  conflicts = "ignore",
   skipLock = false,
-} = {}): Promise<Record<string, string>> {
+}: ResolveOptions = {}): Promise<{
+  deps: Record<string, string>;
+  graph: Record<string, Record<string, string>>;
+}> {
   if (!checkConfigFile()) {
-    return {};
+    return { deps: {}, graph: {} };
   }
 
   if (!skipLock && checkLockFileLight()) {
     let lockFileJson = readLockFile();
 
     if (lockFileJson && lockFileJson.version === 3) {
-      return lockFileJson.deps;
+      return { deps: lockFileJson.deps, graph: lockFileJson.graph ?? {} };
     }
   }
+
+  // edges from the previous lock (even a stale one) substitute for manifests
+  // of versions absent from the cache; published versions are immutable,
+  // so recorded edges never go stale
+  let lockGraph = readLockFileGraph();
+  let graph: Record<string, Record<string, string>> = {};
 
   let rootDir = getRootDir();
   let packages: Record<string, Dependency & { isRoot: boolean }> = {};
@@ -149,26 +178,54 @@ export async function resolvePackages({
           nestedConfig = readConfig(mopsToml);
         }
       } else if (version) {
-        let cacheDir = getDepCacheName(name, version);
-        // a lock-driven install only caches winning versions, so a later
-        // re-walk (stale lock after add/update/sync) can hit versions
-        // absent from the cache — fetch them instead of crashing
-        if (!isDepCached(cacheDir)) {
-          let ok = await installMopsDep(name, version, {
-            silent: true,
-            ignoreTransitive: true,
-          });
-          if (!ok) {
-            console.error(
-              chalk.red("Error: ") +
-                `Package ${name}@${version} is not in the cache and could not be downloaded`,
+        let pkgId = getPackageId(name, version);
+        let lockedEdges = lockGraph[pkgId];
+        if (lockedEdges) {
+          nestedConfig = {
+            package: { name: getDepName(name), version },
+            dependencies: Object.fromEntries(
+              Object.entries(lockedEdges).map(([depName, depValue]) => [
+                depName,
+                parseDepValue(depName, depValue),
+              ]),
+            ),
+          };
+        } else {
+          let cacheDir = getDepCacheName(name, version);
+          // a lock-driven install only caches winning versions, so a re-walk
+          // with a pre-graph lock can hit versions absent from the cache —
+          // fetch them instead of crashing
+          if (!isDepCached(cacheDir)) {
+            let ok = await installMopsDep(name, version, {
+              silent: true,
+              ignoreTransitive: true,
+            });
+            if (!ok) {
+              console.error(
+                chalk.red("Error: ") +
+                  `Package ${name}@${version} is not in the cache and could not be downloaded`,
+              );
+              process.exit(1);
+            }
+          }
+          nestedConfig = readConfig(
+            path.join(getDepCacheDir(cacheDir), "mops.toml"),
+          );
+        }
+
+        // local path deps are mutable, so a package declaring one is never
+        // recorded — its manifest is always read live
+        if (!(pkgId in graph)) {
+          let nestedDeps = Object.values(nestedConfig.dependencies || {});
+          if (nestedDeps.every((dep) => dep.version || dep.repo)) {
+            graph[pkgId] = Object.fromEntries(
+              nestedDeps.map((dep) => [
+                dep.name,
+                dep.version || dep.repo || "",
+              ]),
             );
-            process.exit(1);
           }
         }
-        nestedConfig = readConfig(
-          path.join(getDepCacheDir(cacheDir), "mops.toml"),
-        );
       }
 
       // collect nested deps
@@ -239,7 +296,7 @@ export async function resolvePackages({
     process.exit(1);
   }
 
-  return Object.fromEntries(
+  let deps = Object.fromEntries(
     Object.entries(packages)
       .map(([name, pkg]) => {
         let version: string;
@@ -260,4 +317,6 @@ export async function resolvePackages({
       })
       .filter(([, version]) => version !== ""),
   );
+
+  return { deps, graph };
 }

--- a/cli/tests/cache-resilience.test.ts
+++ b/cli/tests/cache-resilience.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, jest, test } from "@jest/globals";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -20,18 +26,24 @@ describe("global cache resilience", () => {
   const makeTempCacheHome = async () =>
     await mkdtemp(path.join(os.tmpdir(), "mops-cache-"));
 
-  test("add after a lock-driven install fetches conflict losers instead of crashing", async () => {
+  test("add after a lock-driven install resolves losers from the lock graph", async () => {
     const cwd = await makeTempFixture("conflict-loser");
     const cacheHome = await makeTempCacheHome();
     const env = { CI: undefined, XDG_CACHE_HOME: cacheHome };
     const packagesDir = path.join(cacheHome, "mops", "packages");
+    const lockFile = path.join(cwd, "mops.lock");
 
     try {
       // full install populates the cache with every declared version
       // (winner core@1.0.0 and loser core@2.6.1) and writes mops.lock
       const first = await cli(["install"], { cwd, env });
       expect(first.exitCode).toBe(0);
-      expect(existsSync(path.join(cwd, "mops.lock"))).toBe(true);
+
+      // the lock records declared edges for every registry version visited
+      const lock = JSON.parse(readFileSync(lockFile, "utf8"));
+      expect(Object.keys(lock.graph)).toEqual(
+        expect.arrayContaining(["core@1.0.0", "core@2.6.1"]),
+      );
 
       // fresh machine: the committed lock survives, caches don't
       rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
@@ -43,12 +55,51 @@ describe("global cache resilience", () => {
       expect(existsSync(path.join(packagesDir, "core@1.0.0"))).toBe(true);
       expect(existsSync(path.join(packagesDir, "core@2.6.1"))).toBe(false);
 
-      // the stale-lock re-walk visits the losing version's manifest;
-      // it must be fetched on demand, not crash with ENOENT
+      // the stale-lock re-walk needs the losing version's edges;
+      // the lock graph answers without downloading the package
       const result = await cli(["add", "base@0.16.0"], { cwd, env });
       expect(result.stderr).not.toMatch(/ENOENT/);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toMatch(/Package installed/);
+      expect(existsSync(path.join(packagesDir, "core@2.6.1"))).toBe(false);
+
+      const updated = JSON.parse(readFileSync(lockFile, "utf8"));
+      expect(Object.keys(updated.graph)).toEqual(
+        expect.arrayContaining(["core@1.0.0", "core@2.6.1", "base@0.16.0"]),
+      );
+    } finally {
+      rmSync(cacheHome, { recursive: true, force: true });
+    }
+  });
+
+  test("add with a pre-graph lock falls back to fetching losers on demand", async () => {
+    const cwd = await makeTempFixture("conflict-loser");
+    const cacheHome = await makeTempCacheHome();
+    const env = { CI: undefined, XDG_CACHE_HOME: cacheHome };
+    const packagesDir = path.join(cacheHome, "mops", "packages");
+    const lockFile = path.join(cwd, "mops.lock");
+
+    try {
+      const first = await cli(["install"], { cwd, env });
+      expect(first.exitCode).toBe(0);
+
+      // locks written by older CLIs carry no graph
+      const lock = JSON.parse(readFileSync(lockFile, "utf8"));
+      delete lock.graph;
+      writeFileSync(lockFile, JSON.stringify(lock, null, 2));
+
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+      rmSync(cacheHome, { recursive: true, force: true });
+
+      const second = await cli(["install"], { cwd, env });
+      expect(second.exitCode).toBe(0);
+      expect(existsSync(path.join(packagesDir, "core@2.6.1"))).toBe(false);
+
+      // without recorded edges the re-walk must download the losing
+      // version's manifest instead of crashing with ENOENT
+      const result = await cli(["add", "base@0.16.0"], { cwd, env });
+      expect(result.stderr).not.toMatch(/ENOENT/);
+      expect(result.exitCode).toBe(0);
       expect(
         existsSync(path.join(packagesDir, "core@2.6.1", "mops.toml")),
       ).toBe(true);

--- a/docs/docs/10-mops.lock.md
+++ b/docs/docs/10-mops.lock.md
@@ -43,6 +43,9 @@ _It's only faster when there are no globally cached packages — for example whe
 - Hash of the `[dependencies]` and `[dev-dependencies]` sections of `mops.toml`
 - All transitive dependencies with the final resolved versions
 - Hash of each file of each dependency (retrieved from the Mops registry canister)
+- The declared dependencies of every registry package version in the graph (`graph`), including versions that lost a conflict and were not installed
+
+The `graph` section lets Mops update the lock after `mops add`, `remove`, `update` or `sync` without re-downloading package manifests: published versions are immutable, so recorded dependencies never go stale. Local path dependencies are not recorded — their manifests are always read from disk. Locks written by older CLIs have no `graph`; Mops then falls back to reading manifests from the cache, downloading any that are missing.
 
 Local path dependencies are stored relative to the project root (e.g. `./packages/shared`, `../lib`) so the lockfile is portable across machines. A plain `mops install` will not rewrite an older lock that still has absolute paths — run `mops install --lock update` explicitly. `--lock check` also will not flag absolute local paths (it compares the lock to itself when the deps hash matches). After regenerating, use a CLI that includes this fix; older CLIs treat relative lock paths as cwd-relative and break when run from a subdirectory.
 


### PR DESCRIPTION
Follow-up to [#712](https://github.com/caffeinelabs/mops/pull/712), stacked on its branch.

Regenerating a stale `mops.lock` — what `mops add`, `remove`, `update` and `sync` do — re-walks the dependency graph, and the walk needs the declared dependencies of **every** version in it, including versions that lost a conflict. A lock-driven install deliberately never downloads those losers, so before #712 the walk crashed on them, and since #712 it re-downloads them mid-resolution: correct, but it costs network calls for packages that will never be built against, and it cannot run offline.

The lock now stores the reasoning, not just the answers: a `graph` section records each registry package version's declared dependencies, losers included. The walk reads a package's deps in tier order — lock graph, then cached manifest, then registry download — so lock regeneration becomes a local computation. This is the same design as `pnpm-lock.yaml`, which records the full graph rather than only resolved winners.

```json
{
  "version": 3,
  "deps":  { "core": "1.0.0", "lib": "./lib" },
  "graph": { "core@1.0.0": {}, "core@2.6.1": {} },
  "hashes": { "…": "…" }
}
```

Why the recorded edges are trustworthy: published registry versions are immutable, so an edge recorded once is true forever. Mutable local path dependencies are the exception — packages declaring one are never recorded and their manifests are always read live from disk (which is free, since they are local).

Observable change, on a fresh machine with a committed lock:

Before (with #712): `mops add base@0.16.0` downloads the losing `core@2.6.1` into the global cache just to read its manifest.

After: the add completes without touching `core@2.6.1` at all — the regression test asserts the package is absent from the cache after the add, and that the rewritten lock's `graph` gained the new package's edges.

## Compatibility

`graph` is an optional field on the existing v3 lock, not a version bump. Older CLIs ignore it; if an older CLI rewrites the lock the field disappears, and this CLI treats an absent or partial `graph` as "fall through to cache, then fetch-on-miss" — i.e. exactly the #712 behavior, which a dedicated test now pins by stripping `graph` from a lock and re-running the flow. `mops install --lock update` upgrades a pre-graph lock in place. The graph reader also tolerates a corrupt lock (returns empty instead of erroring), so `--lock update` as a recovery command keeps working.

## What is unchanged

Winner selection, conflict warnings, `deps`, `hashes`, and `--locked` semantics are untouched — the graph only changes *where* the walk reads dependency lists from, not what it computes. GitHub dependencies are not recorded (only commit-pinned ones would be safely immutable) and keep the cache-or-fetch path; worth revisiting if they show up in the same failure class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)