### PR TITLE
perf(cli): carry lock hashes over instead of refetching the whole graph

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
+- Updating the lock after a dependency change no longer refetches file hashes for the whole graph from the registry: hashes of packages already in the lock are carried over (published versions are immutable), and only packages new to the lock are queried. `mops remove` now updates the lock without any registry queries. Explicit `mops install --lock update` still refreshes every hash from the registry, so it remains the recovery command for a lock with corrupt hashes.
 - `mops.lock` is now written atomically (staged temp file + rename), so a concurrent `mops install` can no longer read a half-written lock and crash with `Unexpected end of JSON input`.
 - `mops.lock` now records the declared dependencies of every registry package version in the graph (`graph` section), including versions that lost a conflict. Regenerating a stale lock (`mops add`/`remove`/`update`/`sync`, or after editing `mops.toml`) resolves from these recorded edges instead of reading — and, since the fix below, downloading — manifests of packages that were never installed. Works offline and adds no network calls. Locks written by older CLIs have no `graph` and keep the previous behavior; older CLIs ignore the new field.
 - Fix crashes with a raw `ENOENT: no such file or directory ... mops.toml` on incomplete cache state:

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -73,11 +73,17 @@ export async function checkIntegrity(
 async function getFileHashesFromRegistry(): Promise<
   [string, [string, Uint8Array | number[]][]][]
 > {
-  let packageIds = await getResolvedMopsPackageIds();
+  return getFileHashesByPackageIds(await getResolvedMopsPackageIds());
+}
+
+async function getFileHashesByPackageIds(
+  packageIds: string[],
+): Promise<[string, [string, Uint8Array | number[]][]][]> {
+  if (packageIds.length === 0) {
+    return [];
+  }
   let actor = await mainActor();
-  let fileHashesByPackageIds =
-    await actor.getFileHashesByPackageIds(packageIds);
-  return fileHashesByPackageIds;
+  return actor.getFileHashesByPackageIds(packageIds);
 }
 
 async function getResolvedMopsPackageIds(): Promise<string[]> {
@@ -166,20 +172,25 @@ export function readLockFile(): LockFile | null {
   return null;
 }
 
-// Declared dependency edges from the lock. Tolerates a missing, corrupt or
-// pre-graph lock (unlike readLockFile, which exits on corruption) — the graph
-// is an optimization and its absence must never block regeneration.
-export function readLockFileGraph(): Record<string, Record<string, string>> {
+// Parsed v3 lock, tolerating a missing, corrupt or older-version lock
+// (unlike readLockFile, which exits on corruption). For optimizations that
+// must never block regeneration.
+function readLockFileTolerant(): LockFileV3 | null {
   let lockFile = path.join(getRootDir(), "mops.lock");
   try {
     let lock = JSON.parse(fs.readFileSync(lockFile).toString());
-    if (lock?.version === 3 && lock.graph) {
-      return lock.graph;
+    if (lock?.version === 3) {
+      return lock as LockFileV3;
     }
   } catch {
     // fall through
   }
-  return {};
+  return null;
+}
+
+// Declared dependency edges from the lock; empty for pre-graph locks.
+export function readLockFileGraph(): Record<string, Record<string, string>> {
+  return readLockFileTolerant()?.graph ?? {};
 }
 
 // check if lock file exists and integrity of mopsTomlDepsHash
@@ -214,26 +225,46 @@ export async function updateLockFile({
     skipLock: true,
   });
 
-  let fileHashes = await getFileHashesFromRegistry();
+  let packageIds = [
+    ...new Set(
+      Object.entries(resolvedDeps)
+        .filter(([_, version]) => getDependencyType(version) === "mops")
+        .map(([name, version]) => getPackageId(name, version)),
+    ),
+  ];
+
+  // Hashes of packages already in the lock are carried over: published
+  // versions are immutable, so their file hashes never change. Explicit
+  // `--lock update` refetches everything, so it remains the recovery
+  // command for a lock with corrupt hashes.
+  let hashes: Record<string, Record<string, string>> = {};
+  if (!force) {
+    let oldHashes = readLockFileTolerant()?.hashes ?? {};
+    for (let packageId of packageIds) {
+      let carried = oldHashes[packageId];
+      if (carried) {
+        hashes[packageId] = carried;
+      }
+    }
+  }
+
+  let missingIds = packageIds.filter((packageId) => !hashes[packageId]);
+  let fileHashes = await getFileHashesByPackageIds(missingIds);
+  for (let [packageId, packageFileHashes] of fileHashes) {
+    hashes[packageId] = Object.fromEntries(
+      packageFileHashes.map(([fileId, hash]) => [
+        fileId,
+        bytesToHex(new Uint8Array(hash)),
+      ]),
+    );
+  }
 
   let lockFileJson: LockFileV3 = {
     version: 3,
     mopsTomlDepsHash: getMopsTomlDepsHash(),
     deps: resolvedDeps,
     graph,
-    hashes: fileHashes.reduce(
-      (acc, [packageId, fileHashes]) => {
-        acc[packageId] = fileHashes.reduce(
-          (acc, [fileId, hash]) => {
-            acc[fileId] = bytesToHex(new Uint8Array(hash));
-            return acc;
-          },
-          {} as Record<string, string>,
-        );
-        return acc;
-      },
-      {} as Record<string, Record<string, string>>,
-    ),
+    hashes,
   };
 
   let rootDir = getRootDir();
@@ -390,10 +421,10 @@ export async function checkLockFile(force = false, regenerated = false) {
         console.error(`Locked hash: ${lockedHash}`);
         console.error(`Actual hash: ${localHash}`);
         console.error("");
-        if (regenerated) {
-          // The lock was just rewritten from the registry, so the only way
-          // for a per-file hash to still differ is that .mops/<file> was
-          // edited locally. Point users at the actual fix.
+        if (regenerated && force) {
+          // The lock was just rewritten entirely from the registry, so the
+          // only way for a per-file hash to still differ is that
+          // .mops/<file> was edited locally. Point users at the actual fix.
           let pkgDir = fileId.split("/")[0];
           console.error(
             `.mops/${fileId} differs from the registry — your local copy has been modified.`,
@@ -403,6 +434,17 @@ export async function checkLockFile(force = false, regenerated = false) {
           );
           console.error(
             "To keep custom changes, use a `repo` or `path` entry in mops.toml instead of editing .mops/ directly.",
+          );
+        } else if (regenerated) {
+          // implicit regeneration carries hashes over from the previous
+          // lock, so the mismatch can also be a corrupt carried hash
+          let pkgDir = fileId.split("/")[0];
+          console.error(`.mops/${fileId} does not match the lock.`);
+          console.error(
+            "If you have not modified files under .mops/, a hash carried over from the previous lock may be corrupt.",
+          );
+          console.error(
+            `Run \`mops install --lock update\` to refresh hashes from the registry, or delete the \`.mops/${pkgDir}\` directory and run \`mops install\` to restore the package.`,
           );
         } else {
           console.error(

--- a/cli/tests/cache-resilience.test.ts
+++ b/cli/tests/cache-resilience.test.ts
@@ -108,6 +108,46 @@ describe("global cache resilience", () => {
     }
   });
 
+  test("stale-lock regeneration carries hashes over; --lock update refetches them", async () => {
+    const cwd = await makeTempFixture("success");
+    const cacheHome = await makeTempCacheHome();
+    const env = { CI: undefined, XDG_CACHE_HOME: cacheHome };
+    const lockFile = path.join(cwd, "mops.lock");
+    const tampered = "0".repeat(64);
+
+    try {
+      rmSync(lockFile, { force: true });
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+
+      const first = await cli(["install"], { cwd, env });
+      expect(first.exitCode).toBe(0);
+
+      // corrupt one hash in the lock; the deps hash stays valid
+      const lock = JSON.parse(readFileSync(lockFile, "utf8"));
+      const fileId = Object.keys(lock.hashes["core@1.0.0"])[0] as string;
+      const original = lock.hashes["core@1.0.0"][fileId];
+      lock.hashes["core@1.0.0"][fileId] = tampered;
+      writeFileSync(lockFile, JSON.stringify(lock, null, 2));
+
+      // implicit regeneration (add) carries the corrupt hash over instead of
+      // silently refetching it, and the integrity check reports it loudly
+      const add = await cli(["add", "base@0.16.0"], { cwd, env });
+      expect(add.exitCode).toBe(1);
+      expect(add.stderr).toMatch(/carried over from the previous lock/);
+      const carried = JSON.parse(readFileSync(lockFile, "utf8"));
+      expect(carried.hashes["core@1.0.0"][fileId]).toBe(tampered);
+      expect(carried.hashes["base@0.16.0"]).toBeDefined();
+
+      // explicit --lock update refetches every hash from the registry
+      const recover = await cli(["install", "--lock", "update"], { cwd, env });
+      expect(recover.exitCode).toBe(0);
+      const refreshed = JSON.parse(readFileSync(lockFile, "utf8"));
+      expect(refreshed.hashes["core@1.0.0"][fileId]).toBe(original);
+    } finally {
+      rmSync(cacheHome, { recursive: true, force: true });
+    }
+  });
+
   test("empty global cache dir counts as a miss and is re-downloaded", async () => {
     const cwd = await makeTempFixture("success");
     const cacheHome = await makeTempCacheHome();

--- a/docs/docs/10-mops.lock.md
+++ b/docs/docs/10-mops.lock.md
@@ -47,6 +47,8 @@ _It's only faster when there are no globally cached packages — for example whe
 
 The `graph` section lets Mops update the lock after `mops add`, `remove`, `update` or `sync` without re-downloading package manifests: published versions are immutable, so recorded dependencies never go stale. Local path dependencies are not recorded — their manifests are always read from disk. Locks written by older CLIs have no `graph`; Mops then falls back to reading manifests from the cache, downloading any that are missing.
 
+For the same reason, updating the lock after a dependency change carries file hashes of already-locked packages over and queries the registry only for packages new to the lock. `mops install --lock update` always refetches every hash from the registry, so it remains the recovery command for a lock with corrupt hashes.
+
 Local path dependencies are stored relative to the project root (e.g. `./packages/shared`, `../lib`) so the lockfile is portable across machines. A plain `mops install` will not rewrite an older lock that still has absolute paths — run `mops install --lock update` explicitly. `--lock check` also will not flag absolute local paths (it compares the lock to itself when the deps hash matches). After regenerating, use a CLI that includes this fix; older CLIs treat relative lock paths as cwd-relative and break when run from a subdirectory.
 
 ## CI environments


### PR DESCRIPTION
Follow-up to [#713](https://github.com/caffeinelabs/mops/pull/713), stacked on its branch.

Every lock regeneration asked the registry for the file hashes of **all** resolved packages (`getFileHashesByPackageIds` over the full id list). It is a single batched canister call, but its payload scales with the whole dependency graph — after #713 removed manifest re-downloads, this was the dominant per-`add` network cost, paid on every `mops add`, `remove`, `update` and `sync`.

The same immutability argument as #713 applies: a published version's file hashes can never change, so hashes of packages already present in the lock are carried over verbatim, and the registry is queried only for packages new to the lock. Two consequences worth naming:

- `mops add x` queries hashes for `x` and its newly-locked transitives only — network is now proportional to the change, not the graph.
- `mops remove` regenerates the lock with **zero** registry queries.

## Recovery semantics are preserved deliberately

`mops install --lock update` (any explicit `--lock update`) bypasses the carry-over and refetches every hash, so it remains the one command that repairs a lock with corrupt hashes. This split also has a diagnostic consequence: after an implicit regeneration a hash mismatch can be *either* a locally edited `.mops/` file *or* a corrupt carried-over hash, so the post-regeneration error no longer claims a local edit with certainty on that path — it offers both fixes:

```
Mismatched hash for core@1.0.0/src/Array.mo
.mops/core@1.0.0/src/Array.mo does not match the lock.
If you have not modified files under .mops/, a hash carried over from the previous lock may be corrupt.
Run `mops install --lock update` to refresh hashes from the registry, or delete the `.mops/core@1.0.0` directory and run `mops install` to restore the package.
```

The confident "your local copy has been modified" message still appears when the lock was fully refetched (`--lock update`), where it is provably true.

One behavior change: a lock whose hashes were corrupted no longer gets *silently* repaired as a side effect of the next `mops add` — the corruption is carried, detected, and reported with the fix (asserted by the new test). Silent rewriting erased the evidence; pnpm errors on integrity mismatch the same way.

Also folds away a redundant resolve: `updateLockFile` derived package ids via a second `resolvePackages()` walk; they now come from the resolution it already ran.

## What is unchanged

`--lock check`, lock format, and hash *verification* (every `.mops/` file is still hashed and compared on mutating commands) are untouched — this PR changes where the lock's expected hashes come from, not what gets checked. Locks from older CLIs and v1/v2 locks get no carry-over (full refetch), same as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)