### PR TITLE
ci: stop dropping nested changelog entries in the release rollup

### DIFF
--- a/.github/workflows/prepare-cli-release.yml
+++ b/.github/workflows/prepare-cli-release.yml
@@ -116,15 +116,16 @@ jobs:
           if not next_heading:
               sys.exit("::error::No version heading after ## Next in CHANGELOG.md")
 
-          notes = after_next[: next_heading.start()]
-          bullets = [line for line in notes.splitlines() if line.startswith("- ")]
-          if not bullets:
+          # Keep the block verbatim — filtering to top-level "- " lines would
+          # drop nested bullets, code blocks and continuation lines.
+          notes = after_next[: next_heading.start()].strip("\n")
+          if not re.search(r"^- ", notes, re.M):
               sys.exit("::error::## Next has no changelog entries to release")
 
           rolled = (
               "## Next\n\n"
               f"## {version}\n"
-              + "\n".join(bullets)
+              + notes
               + "\n\n"
               + after_next[next_heading.start() :]
           )


### PR DESCRIPTION
`Prepare CLI release` rebuilt the version section from `## Next` by keeping only lines starting with `- `:

```python
bullets = [line for line in notes.splitlines() if line.startswith("- ")]
```

Everything else in the block was silently discarded — nested bullets, code blocks, continuation paragraphs. [#718](https://github.com/caffeinelabs/mops/pull/718) hit this: the five sub-bullets under the ENOENT entry were dropped, leaving a colon-terminated stub promising a list that no longer existed.

The workflow's own sanity check only asserts the version section is non-empty, so a partially-gutted section passed. Nothing else looks at the rolled-up text before it ships to the changelog and the GitHub release body.

The block is now carried over verbatim, and the has-entries guard is a regex over the block rather than a side effect of the filter.

## Before / After

Given a `## Next` entry with a nested list:

```markdown
## Next
- Fix crashes with a raw `ENOENT` on incomplete cache state:
  - `mops add` used to crash while regenerating the lock.
  - Empty cache directories are deleted and re-downloaded.
```

Before:

```markdown
## 2.22.0
- Fix crashes with a raw `ENOENT` on incomplete cache state:
```

After:

```markdown
## 2.22.0
- Fix crashes with a raw `ENOENT` on incomplete cache state:
  - `mops add` used to crash while regenerating the lock.
  - Empty cache directories are deleted and re-downloaded.
```

## What is unchanged

Flat single-level changelogs — the overwhelmingly common case — roll up byte-identically. Verified by running the fixed script against `main`'s changelog: the output matches [#718](https://github.com/caffeinelabs/mops/pull/718)'s branch after the restore commit, exactly. The empty-`## Next` and no-bullets error paths still exit 1 with the same message, and the trailing-newline preservation is untouched.

The v2.22.0 changelog was repaired directly on `ci/release-2.22.0`, so [#718](https://github.com/caffeinelabs/mops/pull/718) does not need to wait on this.