### PR TITLE
perf(cli)!: parallel installs, query-based verification, lockfile staleness fixes

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -217,7 +217,10 @@ mops update core          # update specific package within caret bound
 mops update --major       # allow updates that cross major versions
 mops update --patch       # restrict to patch bumps only (mutually exclusive with --major)
 mops sync                 # add missing / remove unused packages
+mops sync --dry-run       # print what would change, write nothing
 ```
+
+`mops sync` needs a pinned `[toolchain] moc` — it reads imports with `moc --print-deps`. Packages imported only from `test`/`tests`/`bench`/`benchmark` directories are added to `[dev-dependencies]`; already-declared packages are never moved between sections.
 
 ## Other Commands
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,8 +2,45 @@
 
 ## Next
 
+### Performance
+
+- **Faster CLI startup.** The agent no longer eagerly synchronises time on every invocation, which cost three `read_state` requests against the ICP ledger canister — a canister mops never otherwise talks to, on a different subnet. Clock skew still self-heals: the agent re-syncs against the mops canister and retries once when a replica rejects an expired ingress expiry.
+- **Install telemetry no longer blocks.** `notifyInstalls` is submitted as an ingress message and acknowledged on acceptance instead of waiting for a certified reply (~125 ms rather than ~1.1 s). Delivery is unchanged — the method is `oneway` and never had a stronger guarantee.
+- **`mops install` overlaps the API compatibility check with the install** instead of serialising on it. An incompatible CLI still fails with the same message and exit code, but may now do so after the install rather than before. `mops publish` deliberately still checks first.
+- Net effect on a warm-cache `mops install && mops update` in a fresh directory: roughly 2.2 s → 0.7 s of actual work.
+- **Cold installs no longer serialise on consensus calls.** Download-time hash verification used one consensus update call per package (~1.2–2.5 s each), awaited before the package entered the cache and therefore blocking the next package too. It now uses the registry's query method, and the batched consensus call is made once, only when the lockfile is actually regenerated. A clean clone with a committed lock makes **no** consensus call at all — it verifies against the lock.
+- **Packages install concurrently.** `installDeps` was a sequential loop; it now drives a bounded pool with a fixed request budget (16 concurrent fetches, 8 in CI) shared between the package pool and the per-package file pool, so the two no longer multiply. Transitive levels run one package at a time so the budget holds at any graph depth. Measured: 8 root packages plus transitives, cold cache, 19.7 s → 13.2 s.
+- File metadata and the first chunk of each file are now fetched concurrently rather than chained, halving per-file round trips for the single-chunk case that covers essentially every Motoko source file.
+- Registry file hashes are fetched at most once per process, and chunk concatenation is no longer quadratic. **Breaking for programmatic consumers of the `ic-mops` package**: `downloadFile` and `downloadPackageFiles` now return `Uint8Array` instead of `Array<number>`.
+- Dependency resolution is memoised per process, keyed on the contents of `mops.toml`, `mops.lock` and every local dependency manifest the walk read. A single command resolved the graph 3–5 times from scratch.
+- `syncLocalCache` no longer fans out with unbounded concurrency, which could exhaust file descriptors on large graphs.
+
+### Integrity
+
+- **`mops.lock` is now a trust anchor on the install path.** When the lockfile already covers a package being downloaded, its bytes are verified against the hashes recorded there — a local, committed record — instead of trusting a freshly fetched registry answer. This is the model cargo uses with `Cargo.lock`.
+- Hashes written into `mops.lock` are always consensus-derived. Query replies are signed by a single node rather than agreed by the subnet, so they are used to verify a download but never to mint the lock's contents.
+- New, distinct failures when the two sources disagree, because the diagnosis differs: `mops.lock` versus the registry (one of the two records is wrong — restore the lock from version control or delete it), and the registry contradicting itself between its query and consensus replies (the cached copy is tainted — run `mops cache clean`, and please report it).
+- **Behaviour change**: plain `mops install` now fails when it has to *download* a package whose hashes disagree with the committed lockfile. It remains true that files already on disk under `.mops/` are not re-hashed by an install — `mops verify` is still the command that audits those.
+
+### Fixed
+
+- **A local `path` dependency's own `mops.toml` no longer goes unnoticed.** Adding or bumping a dependency inside a local package left `mops.lock` judged fresh, so `mops install` exited 0, installed nothing, and never passed the new dependency to the compiler — the package then failed to build against a dependency mops had reported as installed. `mops.lock` now records a hash of the `[dependencies]` of every path dependency it reaches, transitively, so editing any of them makes the lockfile stale.
+- **Changing `MOPS_ENV` no longer leaves `mops.lock` pinned to the previous environment.** `{MOPS_ENV}` paths are stored expanded in the lockfile, but the freshness check compared the unexpanded string, so a full `mops install` under a new environment exited 0 and kept building against the old environment's directories. `mops install` now re-resolves, `mops sources` reports the current environment, and `mops install --locked` fails rather than silently using the wrong paths. Note that a committed lockfile now only satisfies `--locked` for the `MOPS_ENV` it was generated under.
+- **`mops sync` no longer destroys a pinned alias dependency.** Given `map = "9.0.1"` and `"map@8.1.0" = "8.1.0"`, sync compared imports (`map@8.1.0`) against alias-stripped manifest keys (`map`), so it reported the alias as both missing and unused — adding it overwrote `map` with `8.1.0`, and a single run could remove the dependency entirely. Aliases are now matched verbatim and added under their own key.
+- `mops sync` adds packages imported only from `test`, `tests`, `bench` or `benchmark` directories to `[dev-dependencies]` rather than `[dependencies]`. Already-declared packages are never moved between sections.
+- `mops sync` removes an unused package from **both** sections when it is declared in both; previously it was only removed from `[dependencies]`, leaving a dangling entry that the next run reported again.
+- `mops sync` is roughly twice as fast — it runs `moc --print-deps` once per file instead of twice.
 - Fixed `mops remove <pkg>` crashing with `Invalid dependency value ""` when the dependency is a local path dep.
 - `mops remove` now echoes the dependency value it removed for GitHub and local path deps, instead of an empty version.
+- `mops remove --dry-run` is now side-effect free. It no longer deletes local cache directories or rewrites a stale `mops.lock`, and it prints `Would remove package …` instead of reporting the removal as done.
+- **`mops cache clean` works on Windows and on non-`ic` networks.** Its safety guard compared a `path.join` result against a forward-slash suffix, so it failed with "Invalid cache directory" on every Windows run and for every network-scoped cache directory. The replacement is separator-agnostic and strictly narrower: it also requires the directory to be inside the global cache root, rejecting a traversing `MOPS_NETWORK`.
+- `mops cache clean` no longer deletes `./.mops` when run outside a project, where an empty root directory made it target the current working directory.
+
+### Added
+
+- `mops sync --dry-run` prints what would be added and removed without touching `mops.toml`, the local cache or `mops.lock`.
+- `mops cache clean --global` cleans only the global cache and keeps the project's `.mops` directory.
+- `mops.lock` gains an optional `localDepsHash` field, written only for projects that declare a local `path` dependency. Those projects have their lockfile regenerated once on the next `mops install`, and `mops install --locked` fails until the regenerated lockfile is committed. Projects without path dependencies are unaffected — the field is omitted entirely and existing lockfiles stay valid.
 - Temporary compatibility shim: `mops add`, `remove`, `install`, `sync` and `update` again accept the removed 2.x flag `--lock <check|update|ignore>` instead of failing to parse. The value is ignored — including `check`, which is **not** treated as `--locked` — so v2 call sites keep working during the 3.x rollout. Migrate to `mops install --locked` for CI enforcement; the flag will be removed.
 
 ## 3.0.0 (unreleased)

--- a/cli/api/actors.ts
+++ b/cli/api/actors.ts
@@ -1,4 +1,5 @@
 import { Actor, HttpAgent, Identity } from "@icp-sdk/core/agent";
+import { IDL } from "@icp-sdk/core/candid";
 import { Principal } from "@icp-sdk/core/principal";
 
 import { _SERVICE, idlFactory } from "../declarations/main/main.did.js";
@@ -24,7 +25,10 @@ let getAgent = async (identity?: Identity): Promise<HttpAgent> => {
       shouldFetchRootKey: network === "local",
       verifyQuerySignatures:
         process.env.MOPS_VERIFY_QUERY_SIGNATURES !== "false",
-      shouldSyncTime: true,
+      // No eager syncTime: it costs three read_state calls to an unrelated
+      // canister on every invocation. The agent syncs lazily instead, on the
+      // first IngressExpiryInvalid response.
+      shouldSyncTime: false,
     });
 
     agentPromiseByPrincipal.set(principal, agentPromise);
@@ -41,6 +45,31 @@ export let mainActor = async (identity?: Identity): Promise<_SERVICE> => {
   return Actor.createActor(idlFactory, {
     agent,
     canisterId,
+  });
+};
+
+// Calls a `oneway` method on the main canister. A `oneway` method has no reply,
+// but `Actor` still routes it through the update path and blocks on the certified
+// result (~2s). Submitting to the v2 call endpoint instead returns as soon as the
+// replica accepts the ingress message, which is all the delivery guarantee a
+// `oneway` call ever had.
+export let mainOnewayCall = async <M extends keyof _SERVICE & string>(
+  methodName: M,
+  args: Parameters<_SERVICE[M]>,
+): Promise<void> => {
+  let agent = await getAgent();
+  let canisterId = getEndpoint(getNetwork()).canisterId;
+  let func = idlFactory({ IDL }).fieldsAsObject()[methodName];
+
+  if (!func) {
+    throw new Error(`Unknown main canister method "${methodName}"`);
+  }
+
+  await agent.call(canisterId, {
+    methodName,
+    arg: IDL.encode(func.argTypes, args),
+    effectiveCanisterId: canisterId,
+    callSync: false,
   });
 };
 

--- a/cli/api/downloadPackageFiles.ts
+++ b/cli/api/downloadPackageFiles.ts
@@ -9,13 +9,13 @@ export async function downloadPackageFiles(
   version = "",
   threads = 8,
   onLoad = (_fileIds: string[], _fileId: string) => {},
-): Promise<Map<string, Array<number>>> {
+): Promise<Map<string, Uint8Array>> {
   version = await resolveVersion(pkg, version);
 
   let { storageId, fileIds } = await getPackageFilesInfo(pkg, version);
   let storage = await storageActor(storageId);
 
-  let filesData = new Map<string, Array<number>>();
+  let filesData = new Map<string, Uint8Array>();
   await parallel(threads, fileIds, async (fileId: string) => {
     let { path, data } = await downloadFile(storage, fileId);
     filesData.set(path, data);
@@ -64,32 +64,72 @@ export async function getFileIds(
   return filesIds;
 }
 
+function concatChunks(chunks: Uint8Array[]): Uint8Array {
+  if (chunks.length === 1) {
+    return chunks[0] as Uint8Array;
+  }
+  let size = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  let data = new Uint8Array(size);
+  let offset = 0;
+  for (let chunk of chunks) {
+    data.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return data;
+}
+
 // download single file
 export async function downloadFile(
   storage: Storage | string,
   fileId: string,
-): Promise<{ path: string; data: Array<number> }> {
+): Promise<{ path: string; data: Uint8Array }> {
   if (typeof storage === "string") {
     storage = await storageActor(Principal.fromText(storage));
   }
-  let fileMetaRes = await storage.getFileMeta(fileId);
+
+  // Chunks are 1.5mb (see `publish.ts`), so virtually every published file is a
+  // single chunk. Speculating on chunk 0 alongside the meta halves the query
+  // round trips per file. `allSettled` so a failure on one leg cannot surface
+  // as an unhandled rejection on the other.
+  let [metaSettled, firstChunkSettled] = await Promise.allSettled([
+    storage.getFileMeta(fileId),
+    storage.downloadChunk(fileId, 0n),
+  ]);
+
+  if (metaSettled.status === "rejected") {
+    throw metaSettled.reason;
+  }
+  let fileMetaRes = metaSettled.value;
   if ("err" in fileMetaRes) {
     throw fileMetaRes.err;
   }
   let fileMeta = fileMetaRes.ok;
 
-  let data: Array<number> = [];
-  for (let i = 0n; i < fileMeta.chunkCount; i++) {
+  // An empty file is published with no chunks at all, so chunk 0 legitimately
+  // does not exist and its error must be ignored.
+  if (fileMeta.chunkCount === 0n) {
+    return { path: fileMeta.path, data: new Uint8Array() };
+  }
+
+  if (firstChunkSettled.status === "rejected") {
+    throw firstChunkSettled.reason;
+  }
+  let firstChunkRes = firstChunkSettled.value;
+  if ("err" in firstChunkRes) {
+    throw firstChunkRes.err;
+  }
+
+  let chunks = [Uint8Array.from(firstChunkRes.ok)];
+  for (let i = 1n; i < fileMeta.chunkCount; i++) {
     let chunkRes = await storage.downloadChunk(fileId, i);
     if ("err" in chunkRes) {
       throw chunkRes.err;
     }
-    let chunk = chunkRes.ok;
-    data = [...data, ...chunk];
+    chunks.push(Uint8Array.from(chunkRes.ok));
   }
 
   return {
     path: fileMeta.path,
-    data: data,
+    data: concatChunks(chunks),
   };
 }

--- a/cli/cache.ts
+++ b/cli/cache.ts
@@ -132,26 +132,6 @@ export function getGithubDepCacheName(name: string, repo: string) {
   );
 }
 
-export let addCache = async (cacheName: string, source: string) => {
-  let dest = path.join(getGlobalCacheDir(), "packages", cacheName);
-  let staging = createStagingDir(dest);
-
-  try {
-    await new Promise<void>((resolve, reject) => {
-      ncp.ncp(source, staging, { stopOnErr: true }, (err) => {
-        if (err) {
-          reject(err);
-        }
-        resolve();
-      });
-    });
-    commitStagingDir(staging, dest);
-  } catch (err) {
-    fs.rmSync(staging, { recursive: true, force: true });
-    throw err;
-  }
-};
-
 export let copyCache = async (cacheName: string, dest: string) => {
   let source = path.join(getGlobalCacheDir(), "packages", cacheName);
   let staging = createStagingDir(dest);
@@ -183,18 +163,49 @@ export let cacheSize = async () => {
   return (size / 1024 / 1024).toFixed(2) + " MB";
 };
 
-export let cleanCache = async () => {
-  if (
-    !getGlobalCacheDir().endsWith("mops/cache") &&
-    !getGlobalCacheDir().endsWith("/mops") &&
-    !getGlobalCacheDir().endsWith("/mops/" + getNetwork())
-  ) {
-    throw new Error("Invalid cache directory: " + getGlobalCacheDir());
+// Refuse to recursively delete anything that is not the mops cache. The dir
+// must sit inside `globalCacheDir` and its trailing segments must be `mops`,
+// `mops/cache` (Windows), each optionally followed by the network segment.
+// Separators are compared per-segment because `path.join` yields backslashes
+// on Windows.
+export function assertGlobalCacheDir(dir: string, cacheRoot = globalCacheDir) {
+  let resolved = path.resolve(dir);
+  let base = path.resolve(cacheRoot);
+  let inBase =
+    resolved === base ||
+    resolved.startsWith(base + "/") ||
+    resolved.startsWith(base + "\\");
+
+  let segments = resolved.split(/[\\/]+/).filter(Boolean);
+  let network = getNetwork();
+  if (network !== "ic" && segments.at(-1) === network) {
+    segments.pop();
+  }
+  if (segments.at(-1) === "cache") {
+    segments.pop();
   }
 
-  // local cache
-  fs.rmSync(path.join(getRootDir(), ".mops"), { recursive: true, force: true });
+  if (!inBase || segments.at(-1) !== "mops" || segments.length < 2) {
+    throw new Error("Invalid cache directory: " + resolved);
+  }
+}
+
+type CleanCacheOptions = {
+  // Leave the project's `.mops` directory alone.
+  global?: boolean;
+};
+
+export let cleanCache = async ({ global = false }: CleanCacheOptions = {}) => {
+  let globalCache = getGlobalCacheDir();
+  assertGlobalCacheDir(globalCache);
+
+  // local cache — outside a project `getRootDir()` is empty, which would
+  // target `.mops` in the current working directory
+  let rootDir = getRootDir();
+  if (!global && rootDir) {
+    fs.rmSync(path.join(rootDir, ".mops"), { recursive: true, force: true });
+  }
 
   // global cache
-  fs.rmSync(getGlobalCacheDir(), { recursive: true, force: true });
+  fs.rmSync(globalCache, { recursive: true, force: true });
 };

--- a/cli/check-requirements.ts
+++ b/cli/check-requirements.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { SemVer } from "semver";
 import chalk from "chalk";
 
@@ -9,7 +9,7 @@ import { resolvePackages } from "./resolve-packages.js";
 import { getMocSemVer } from "./helpers/get-moc-version.js";
 import { getLintokoSemVer } from "./helpers/get-lintoko-version.js";
 import { getPackageId } from "./helpers/get-package-id.js";
-import type { Requirements } from "./types.js";
+import type { Config, Requirements } from "./types.js";
 
 type ToolRequirement = keyof Requirements;
 
@@ -20,6 +20,23 @@ const TOOL_REQUIREMENTS: {
   { tool: "moc", getInstalled: getMocSemVer },
   { tool: "lintoko", getInstalled: getLintokoSemVer },
 ];
+
+// A command can reach this twice (`mops add` runs it after installAll), and it
+// TOML-parses every installed package's manifest each time. Keyed on the stat so
+// a rewritten manifest is still picked up.
+const configCache = new Map<string, { stamp: string; config: Config }>();
+
+function readPackageConfig(configPath: string): Config {
+  let stat = statSync(configPath);
+  let stamp = `${stat.mtimeMs}|${stat.size}`;
+  let cached = configCache.get(configPath);
+  if (cached?.stamp === stamp) {
+    return cached.config;
+  }
+  let config = readConfig(configPath);
+  configCache.set(configPath, { stamp, config });
+  return config;
+}
 
 export async function checkRequirements({ verbose = false } = {}) {
   let rootDir = getRootDir();
@@ -46,7 +63,7 @@ export async function checkRequirements({ verbose = false } = {}) {
             continue;
           }
         }
-        let depConfig = readConfig(configPath);
+        let depConfig = readPackageConfig(configPath);
         let required = depConfig.requirements?.[tool];
 
         if (required) {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -192,15 +192,20 @@ program
       process.exit(1);
     }
 
-    let compatible = await checkApiCompatibility();
+    // The compatibility check is a read-only query, so it overlaps the install
+    // instead of costing a round trip in front of it. An incompatible CLI still
+    // reports the same error and skips everything downstream.
+    let [compatible, ok] = await Promise.all([
+      checkApiCompatibility(),
+      installAll({
+        ...options,
+        lock: options.locked ? "locked" : "maintain",
+      }),
+    ]);
+
     if (!compatible) {
       return;
     }
-
-    let ok = await installAll({
-      ...options,
-      lock: options.locked ? "locked" : "maintain",
-    });
 
     // Bail before the conflicts check: it re-resolves, which reads dependency
     // manifests that a failed install may never have written.
@@ -333,9 +338,13 @@ program
   .command("cache")
   .description("Manage cache")
   .addArgument(new Argument("<sub>").choices(["size", "clean", "show"]))
-  .action(async (sub) => {
+  .option(
+    "--global",
+    "cache clean: clean only the global cache, keep the project's .mops directory",
+  )
+  .action(async (sub, options) => {
     if (sub == "clean") {
-      await cleanCache();
+      await cleanCache(options);
       console.log("Cache cleaned");
     } else if (sub == "size") {
       let size = await cacheSize();
@@ -799,8 +808,12 @@ program
   .command("sync")
   .description("Add missing packages and remove unused packages")
   .addOption(legacyLockOption())
-  .action(async () => {
-    await sync();
+  .option(
+    "--dry-run",
+    "Print what would be added and removed without changing mops.toml, the local cache or mops.lock",
+  )
+  .action(async (options) => {
+    await sync(options);
   });
 
 // outdated

--- a/cli/commands/install/install-concurrency.ts
+++ b/cli/commands/install/install-concurrency.ts
@@ -1,0 +1,82 @@
+import process from "node:process";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// installMopsDep already downloads one package's files in parallel, so a pool
+// of packages multiplies with it — the budget below is packages x file threads,
+// not either on its own. GitHub Actions runners fail with "fetch failed" under
+// high concurrency (installMopsDep caps its own file threads at 4 there for the
+// same reason), so the whole budget halves in CI.
+const MAX_PACKAGE_CONCURRENCY = process.env.GITHUB_ENV ? 2 : 4;
+const REQUEST_BUDGET = process.env.GITHUB_ENV ? 8 : 16;
+
+// installMopsDep's own default, which a single package still gets to use.
+const MAX_FILE_THREADS = 12;
+
+// How many packages may install at once. An explicit per-package thread count
+// (`mops sources` passes 6) narrows the pool instead of multiplying with it.
+export function packageConcurrency(depCount: number, threads?: number): number {
+  let cap = threads
+    ? Math.floor(REQUEST_BUDGET / threads)
+    : MAX_PACKAGE_CONCURRENCY;
+  return Math.max(1, Math.min(MAX_PACKAGE_CONCURRENCY, cap, depCount));
+}
+
+export function fileThreadsPerPackage(packages: number): number {
+  return Math.max(
+    1,
+    Math.min(MAX_FILE_THREADS, Math.floor(REQUEST_BUDGET / packages)),
+  );
+}
+
+// One install run. The top-level call decides `threads`; transitive levels
+// inherit it because they cannot see how wide the pool above them is.
+export type InstallScope = {
+  threads: number;
+  inFlight: Map<string, Promise<boolean>>;
+};
+
+const scopeStorage = new AsyncLocalStorage<InstallScope>();
+
+export function getInstallScope(): InstallScope | undefined {
+  return scopeStorage.getStore();
+}
+
+export function createInstallScope(threads: number): InstallScope {
+  return { threads, inFlight: new Map() };
+}
+
+export function runInInstallScope<T>(
+  scope: InstallScope,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return scopeStorage.run(scope, fn);
+}
+
+// Share one install between branches of the graph that request the same
+// package. Failures are dropped from the map so a later request retries instead
+// of inheriting a `false` from a transient error.
+export function dedupeInstall(
+  key: string,
+  fn: () => Promise<boolean>,
+): Promise<boolean> {
+  let scope = getInstallScope();
+  if (!scope) {
+    return fn();
+  }
+  let existing = scope.inFlight.get(key);
+  if (existing) {
+    return existing;
+  }
+  let promise = fn().then(
+    (ok) => {
+      ok || scope.inFlight.delete(key);
+      return ok;
+    },
+    (err) => {
+      scope.inFlight.delete(key);
+      throw err;
+    },
+  );
+  scope.inFlight.set(key, promise);
+  return promise;
+}

--- a/cli/commands/install/install-deps.ts
+++ b/cli/commands/install/install-deps.ts
@@ -1,5 +1,14 @@
 import { Dependency } from "../../types.js";
+import { parallel } from "../../parallel.js";
 import { installDep } from "./install-dep.js";
+import {
+  createInstallScope,
+  dedupeInstall,
+  fileThreadsPerPackage,
+  getInstallScope,
+  packageConcurrency,
+  runInInstallScope,
+} from "./install-concurrency.js";
 
 type InstallDepsOptions = {
   verbose?: boolean;
@@ -7,6 +16,22 @@ type InstallDepsOptions = {
   threads?: number;
   ignoreTransitive?: boolean;
 };
+
+// Identifies the work, not the declaration: two packages asking for the same
+// version are one install. A local path resolves against its parent, so the
+// parent belongs in the key.
+function depKey(
+  dep: Dependency,
+  ignoreTransitive?: boolean,
+  parentPkgPath?: string,
+): string {
+  let source = dep.repo
+    ? dep.repo
+    : dep.path
+      ? `${parentPkgPath || ""}:${dep.path}`
+      : dep.version;
+  return `${dep.name}|${source}|${ignoreTransitive ? 1 : 0}`;
+}
 
 // install all dependencies
 // returns actual installed dependencies
@@ -16,18 +41,37 @@ export async function installDeps(
   { verbose, silent, threads, ignoreTransitive }: InstallDepsOptions = {},
   parentPkgPath?: string,
 ): Promise<boolean> {
+  let scope = getInstallScope();
+  // Transitive levels install one package at a time: every branch of the graph
+  // is then a single chain, so the top-level pool alone bounds how many
+  // packages are in flight however deep the graph goes.
+  let concurrency = scope ? 1 : packageConcurrency(deps.length, threads);
+  let depThreads =
+    threads ?? scope?.threads ?? fileThreadsPerPackage(concurrency);
+
   let ok = true;
 
-  for (const dep of deps) {
-    let res = await installDep(
-      dep,
-      { verbose, silent, threads, ignoreTransitive },
-      parentPkgPath,
+  // A failed dependency does not abort the rest, same as the sequential loop
+  // this replaced — every package gets its own error message.
+  let install = async (dep: Dependency) => {
+    let res = await dedupeInstall(
+      depKey(dep, ignoreTransitive, parentPkgPath),
+      () =>
+        installDep(
+          dep,
+          { verbose, silent, threads: depThreads, ignoreTransitive },
+          parentPkgPath,
+        ),
     );
     if (!res) {
       ok = false;
     }
-  }
+  };
+
+  let run = () => parallel(concurrency, deps, install);
+  await (scope
+    ? run()
+    : runInInstallScope(createInstallScope(depThreads), run));
 
   return ok;
 }

--- a/cli/commands/install/install-mops-dep.ts
+++ b/cli/commands/install/install-mops-dep.ts
@@ -86,9 +86,10 @@ export async function installMopsDep(
   }
   // download
   else {
-    // GitHub Actions fails with "fetch failed" if there are multiple concurrent actions
+    // GitHub Actions fails with "fetch failed" if there are multiple concurrent actions.
+    // A cap, not an assignment — the caller budgets across packages and may want fewer.
     if (process.env.GITHUB_ENV) {
-      threads = 4;
+      threads = Math.min(threads, 4);
     }
 
     try {
@@ -96,7 +97,7 @@ export async function installMopsDep(
 
       total = fileIds.length + 2;
 
-      let filesData = new Map();
+      let filesData = new Map<string, Uint8Array>();
       let storage = await storageActor(storageId);
 
       await parallel(threads, fileIds, async (fileId: string) => {

--- a/cli/commands/install/sync-local-cache.ts
+++ b/cli/commands/install/sync-local-cache.ts
@@ -7,9 +7,17 @@ import {
   sweepStaleStagingDirs,
 } from "../../cache.js";
 import { getDependencyType, getRootDir } from "../../mops.js";
+import { parallel } from "../../parallel.js";
 import { resolvePackages } from "../../resolve-packages.js";
 import { installFromGithub } from "./install-from-github.js";
 import { installMopsDep } from "./install-mops-dep.js";
+import { fileThreadsPerPackage } from "./install-concurrency.js";
+
+// Each task is a recursive directory copy, so a graph-wide fan-out runs out of
+// file descriptors. On the repair path below a task also downloads, hence the
+// matching share of the request budget.
+const COPY_CONCURRENCY = 8;
+const REPAIR_THREADS = fileThreadsPerPackage(COPY_CONCURRENCY);
 
 export async function syncLocalCache({ verbose = false } = {}): Promise<
   Record<string, string>
@@ -23,8 +31,10 @@ export async function syncLocalCache({ verbose = false } = {}): Promise<
 
   let installedDeps: Record<string, string> = {};
 
-  await Promise.all(
-    Object.entries(resolvedPackages).map(async ([name, value]) => {
+  await parallel(
+    COPY_CONCURRENCY,
+    Object.entries(resolvedPackages),
+    async ([name, value]) => {
       let depType = getDependencyType(value);
 
       if (depType === "mops" || depType === "github") {
@@ -43,6 +53,7 @@ export async function syncLocalCache({ verbose = false } = {}): Promise<
                 ? await installMopsDep(name, value, {
                     silent: true,
                     ignoreTransitive: true,
+                    threads: REPAIR_THREADS,
                   })
                 : await installFromGithub(name, value, { silent: true });
             if (!ok) {
@@ -54,7 +65,7 @@ export async function syncLocalCache({ verbose = false } = {}): Promise<
           await copyCache(cacheName, dest);
         }
       }
-    }),
+    },
   ).catch((err) => {
     // ncp rejects with an array of errors
     throw Array.isArray(err) ? err[0] : err;

--- a/cli/commands/remove.ts
+++ b/cli/commands/remove.ts
@@ -127,8 +127,12 @@ export async function remove(
     let cacheName = getDepCacheName(dep.name, depValue);
     let localCacheDir = path.join(getRootDir(), ".mops", cacheName);
     if (localCacheDir && fs.existsSync(localCacheDir)) {
-      dryRun || deleteSync([localCacheDir], { force: true });
-      verbose && console.log(`Removed local cache ${localCacheDir}`);
+      if (dryRun) {
+        verbose && console.log(`Would remove local cache ${localCacheDir}`);
+      } else {
+        deleteSync([localCacheDir], { force: true });
+        verbose && console.log(`Removed local cache ${localCacheDir}`);
+      }
     }
   }
 
@@ -139,7 +143,17 @@ export async function remove(
   if (dev && config["dev-dependencies"]) {
     delete config["dev-dependencies"][name];
   }
-  dryRun || writeConfig(config);
+  // A dry run must not touch mops.toml, the local cache or mops.lock — the
+  // lockfile is rewritten by `checkIntegrity` even when it was only stale.
+  if (dryRun) {
+    console.log(
+      chalk.yellow("Would remove package ") +
+        `${name} = "${pkgDetails.repo || pkgDetails.path || version}"`,
+    );
+    return;
+  }
+
+  writeConfig(config);
 
   await syncLocalCache();
   await checkIntegrity(lock);

--- a/cli/commands/sync.ts
+++ b/cli/commands/sync.ts
@@ -8,52 +8,158 @@ import { remove } from "./remove.js";
 import { checkIntegrity } from "../integrity.js";
 import { toolchain } from "./toolchain/index.js";
 import { MOTOKO_IGNORE_PATTERNS } from "../constants.js";
-import { getDepName } from "../helpers/get-dep-name.js";
 
-export async function sync() {
+export type SyncOptions = {
+  dryRun?: boolean;
+};
+
+export type UsedPackages = {
+  prod: Set<string>;
+  dev: Set<string>;
+};
+
+export type DeclaredPackages = {
+  deps: Set<string>;
+  devDeps: Set<string>;
+};
+
+export type SyncPlan = {
+  add: { name: string; dev: boolean }[];
+  remove: { name: string; dev: boolean }[];
+};
+
+// Same directory shapes `mops test` and `mops bench` collect from.
+const DEV_SOURCE_PATTERNS = ["**/test?(s)/**/*.mo", "**/bench?(mark)/**/*.mo"];
+
+export async function sync({ dryRun = false }: SyncOptions = {}) {
   if (!checkConfigFile()) {
     return;
   }
 
-  let missing = await getMissingPackages();
-  let unused = await getUnusedPackages();
-
-  missing.length &&
-    console.log(`${chalk.yellow("Missing packages:")} ${missing.join(", ")}`);
-  unused.length &&
-    console.log(`${chalk.yellow("Unused packages:")} ${unused.join(", ")}`);
-
+  let used = await getUsedPackages();
   let config = readConfig();
-  let deps = new Set(Object.keys(config.dependencies || {}));
-  let devDeps = new Set(Object.keys(config["dev-dependencies"] || {}));
+  let declared = {
+    deps: new Set(Object.keys(config.dependencies || {})),
+    devDeps: new Set(Object.keys(config["dev-dependencies"] || {})),
+  };
+  let plan = computeSyncPlan(used, declared);
 
-  // add missing packages
-  for (let pkg of missing) {
-    await add(pkg, { lock: "skip" });
+  let names = (entries: { name: string }[]) =>
+    [...new Set(entries.map((entry) => entry.name))].join(", ");
+
+  plan.add.length &&
+    console.log(`${chalk.yellow("Missing packages:")} ${names(plan.add)}`);
+  plan.remove.length &&
+    console.log(`${chalk.yellow("Unused packages:")} ${names(plan.remove)}`);
+
+  if (dryRun) {
+    for (let { name, dev } of plan.add) {
+      console.log(chalk.green("Would add ") + name + (dev ? " (dev)" : ""));
+    }
+    for (let { name, dev } of plan.remove) {
+      console.log(chalk.red("Would remove ") + name + (dev ? " (dev)" : ""));
+    }
+    if (!plan.add.length && !plan.remove.length) {
+      console.log("Everything is in sync");
+    }
+    return;
   }
 
-  // remove unused packages
-  for (let pkg of unused) {
-    let dev = devDeps.has(pkg) && !deps.has(pkg);
-    await remove(pkg, { dev, lock: "skip" });
+  // `asName` keeps the declared key intact — `add` otherwise splits a pinned
+  // alias like `map@8.1.0` and writes it back under the bare `map` key.
+  for (let { name, dev } of plan.add) {
+    await add(name, { dev, lock: "skip" }, name);
+  }
+
+  for (let { name, dev } of plan.remove) {
+    await remove(name, { dev, lock: "skip" });
   }
 
   await checkIntegrity();
 }
 
-async function getUsedPackages(): Promise<string[]> {
-  let rootDir = getRootDir();
-  let mocPath = await toolchain.bin("moc");
+// `mo:map@8.1.0/Map` -> `map@8.1.0`. An import names the mops.toml key
+// verbatim, pinned alias included, so it must not be reduced to the base
+// package name.
+export function parseImportedPackage(dep: string): string | undefined {
+  let trimmed = dep.trim();
+  if (
+    !trimmed.startsWith("mo:") ||
+    trimmed.startsWith("mo:prim") ||
+    trimmed.startsWith("mo:⛔")
+  ) {
+    return undefined;
+  }
+  return trimmed.replace(/^mo:([^/]+).*$/, "$1") || undefined;
+}
 
-  let files = globSync("**/*.mo", {
+export function computeSyncPlan(
+  used: UsedPackages,
+  declared: DeclaredPackages,
+): SyncPlan {
+  let plan: SyncPlan = { add: [], remove: [] };
+  let isDeclared = (name: string) =>
+    declared.deps.has(name) || declared.devDeps.has(name);
+  let isUsed = (name: string) => used.prod.has(name) || used.dev.has(name);
+
+  for (let name of used.prod) {
+    if (!isDeclared(name)) {
+      plan.add.push({ name, dev: false });
+    }
+  }
+  for (let name of used.dev) {
+    if (!isDeclared(name) && !used.prod.has(name)) {
+      plan.add.push({ name, dev: true });
+    }
+  }
+
+  // A name declared in both sections is unused in both, so drop both entries.
+  for (let name of declared.deps) {
+    if (!isUsed(name)) {
+      plan.remove.push({ name, dev: false });
+    }
+  }
+  for (let name of declared.devDeps) {
+    if (!isUsed(name)) {
+      plan.remove.push({ name, dev: true });
+    }
+  }
+
+  return plan;
+}
+
+// Motoko sources of the project, split by whether they only ship as tests or
+// benchmarks.
+export function getSourceFiles(rootDir: string): {
+  prod: string[];
+  dev: string[];
+} {
+  let globOptions = {
     cwd: rootDir,
     nocase: true,
     ignore: MOTOKO_IGNORE_PATTERNS,
-  });
+  };
+  let devFiles = new Set(globSync(DEV_SOURCE_PATTERNS, globOptions));
+  let files = globSync("**/*.mo", globOptions);
+  return {
+    prod: files.filter((file) => !devFiles.has(file)),
+    dev: files.filter((file) => devFiles.has(file)),
+  };
+}
 
-  let packages: Set<string> = new Set();
+async function getUsedPackages(): Promise<UsedPackages> {
+  let rootDir = getRootDir();
+  let mocPath = await toolchain.bin("moc");
+
+  let sourceFiles = getSourceFiles(rootDir);
+  let devFiles = new Set(sourceFiles.dev);
+  let files = [...sourceFiles.prod, ...sourceFiles.dev];
+
+  let used: UsedPackages = { prod: new Set(), dev: new Set() };
 
   for (let file of files) {
+    let target = devFiles.has(file) ? used.dev : used.prod;
+
     let deps: string[] = execSync(
       `${mocPath} --print-deps ${path.join(rootDir, file)}`,
     )
@@ -62,37 +168,12 @@ async function getUsedPackages(): Promise<string[]> {
       .split("\n");
 
     for (let dep of deps) {
-      if (
-        dep.startsWith("mo:") &&
-        !dep.startsWith("mo:prim") &&
-        !dep.startsWith("mo:⛔")
-      ) {
-        packages.add(dep.replace(/^mo:([^/]+).*$/, "$1"));
+      let pkg = parseImportedPackage(dep);
+      if (pkg) {
+        target.add(pkg);
       }
     }
   }
 
-  return [...packages];
-}
-
-async function getMissingPackages(): Promise<string[]> {
-  let config = readConfig();
-  let allDepNames = new Set(
-    [
-      ...Object.keys(config.dependencies || {}),
-      ...Object.keys(config["dev-dependencies"] || {}),
-    ].map((key) => getDepName(key)),
-  );
-  let used = await getUsedPackages();
-  return used.filter((pkg) => !allDepNames.has(pkg));
-}
-
-async function getUnusedPackages(): Promise<string[]> {
-  let config = readConfig();
-  let allDeps = [
-    ...Object.keys(config.dependencies || {}),
-    ...Object.keys(config["dev-dependencies"] || {}),
-  ];
-  let used = new Set(await getUsedPackages());
-  return allDeps.filter((key) => !used.has(getDepName(key)));
+  return used;
 }

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -5,8 +5,11 @@ import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 import { getDependencyType, getRootDir, readConfig } from "./mops.js";
 import { mainActor } from "./api/actors.js";
+import { getEndpoint, getNetwork } from "./api/network.js";
 import { resolveDepsAndGraph } from "./resolve-packages.js";
 import { getPackageId } from "./helpers/get-package-id.js";
+import { normalizeLocalDepPath } from "./helpers/normalize-local-path.js";
+import { Dependency } from "./types.js";
 
 type LockFileV1 = {
   version: 1;
@@ -23,6 +26,11 @@ type LockFileV2 = {
 type LockFileV3 = {
   version: 3;
   mopsTomlDepsHash: string;
+  // the `[dependencies]` of every local `path` dependency, transitively, keyed
+  // by directory — so editing one, or pointing `{MOPS_ENV}` at another, makes
+  // the lock stale; omitted when the project declares no path dependency, which
+  // is what keeps locks written before this field valid
+  localDepsHash?: string;
   hashes: Record<string, Record<string, string>>;
   deps: Record<string, string>;
   // declared dependency edges per registry package version (losers included),
@@ -121,6 +129,16 @@ function hasValidShape(lock: unknown): boolean {
     return false;
   }
 
+  // Absent is the valid state for a project with no local path deps, and for
+  // locks written by a CLI that predates the field.
+  if (
+    candidate["version"] === CURRENT_LOCK_VERSION &&
+    candidate["localDepsHash"] !== undefined &&
+    typeof candidate["localDepsHash"] !== "string"
+  ) {
+    return false;
+  }
+
   return true;
 }
 
@@ -178,6 +196,7 @@ type LockDefect =
   | { kind: "unsupported-version"; version: number }
   | { kind: "legacy-version"; version: number }
   | { kind: "deps-hash"; locked: string; actual: string }
+  | { kind: "local-deps-hash" }
   | { kind: "absolute-paths" }
   | { kind: "deps-mismatch"; problems: string[] }
   | { kind: "hashes-deps-mismatch"; detail: string };
@@ -208,6 +227,14 @@ function inspectLockFile(): LockDefect | null {
   let actual = getMopsTomlDepsHash();
   if (lock.mopsTomlDepsHash !== actual) {
     return { kind: "deps-hash", locked: lock.mopsTomlDepsHash, actual };
+  }
+
+  // The root deps hash covers the declared `path` string, not what is behind it,
+  // so without this a local dep gaining a dependency of its own — or a
+  // `{MOPS_ENV}` path pointing somewhere else — leaves the lock looking fresh
+  // and the new dependency never gets installed.
+  if (lock.localDepsHash !== getLocalDepsHash()) {
+    return { kind: "local-deps-hash" };
   }
 
   // Locks written before local paths became root-relative store machine-specific
@@ -260,26 +287,232 @@ export function checkLockFileLight(): boolean {
   return inspectLockFile() === null;
 }
 
+type HashSource =
+  // `getFileHashesByPackageIds`, an update call, so the answer went through
+  // consensus.
+  | "update"
+  // `getFileHashesQuery`, a node-signed but not consensus-verified reply.
+  | "query";
+
+type MemoEntry = {
+  packageId: string;
+  source: HashSource;
+  hashes: Record<string, string>;
+};
+
+// Published versions are immutable, so a package's file hashes can never change
+// once published — that is what makes reusing a fetched answer safe. In-process
+// only, never persisted, and keyed by registry endpoint so two networks (or an
+// overridden canister id) cannot collide.
+const fileHashesMemo = new Map<string, MemoEntry>();
+
+function memoKey(packageId: string): string {
+  let { host, canisterId } = getEndpoint(getNetwork());
+  return `${host}|${canisterId}|${packageId}`;
+}
+
+function readMemo(
+  packageId: string,
+  requireConsensus: boolean,
+): Record<string, string> | undefined {
+  let entry = fileHashesMemo.get(memoKey(packageId));
+  if (!entry || (requireConsensus && entry.source === "query")) {
+    return undefined;
+  }
+  return entry.hashes;
+}
+
+function writeMemo(
+  packageId: string,
+  source: HashSource,
+  hashes: Record<string, string>,
+): Record<string, string> {
+  let existing = fileHashesMemo.get(memoKey(packageId));
+  if (!existing || existing.source !== "update") {
+    fileHashesMemo.set(memoKey(packageId), { packageId, source, hashes });
+  }
+  return hashes;
+}
+
+function toHashRecord(
+  fileHashes: Array<[string, Uint8Array | number[]]>,
+): Record<string, string> {
+  return Object.fromEntries(
+    fileHashes.map(([fileId, hash]) => [
+      fileId,
+      bytesToHex(new Uint8Array(hash)),
+    ]),
+  );
+}
+
+// `requireConsensus` is for the lock *validation* paths (`--locked`,
+// `mops verify`): they exist to check the lock against the registry, so they
+// must not be served a memo entry that came from a query reply.
 async function fetchRegistryFileHashes(
   packageIds: string[],
+  { requireConsensus = false }: { requireConsensus?: boolean } = {},
 ): Promise<Record<string, Record<string, string>>> {
-  if (packageIds.length === 0) {
-    return {};
-  }
-  let actor = await mainActor();
-  let fileHashesByPackageIds =
-    await actor.getFileHashesByPackageIds(packageIds);
-
   let hashes: Record<string, Record<string, string>> = {};
+  let missing: string[] = [];
+  for (let packageId of packageIds) {
+    let memoized = readMemo(packageId, requireConsensus);
+    if (memoized) {
+      hashes[packageId] = memoized;
+    } else if (!missing.includes(packageId)) {
+      missing.push(packageId);
+    }
+  }
+  if (missing.length === 0) {
+    return hashes;
+  }
+
+  let actor = await mainActor();
+  let fileHashesByPackageIds = await actor.getFileHashesByPackageIds(missing);
+
   for (let [packageId, fileHashes] of fileHashesByPackageIds) {
-    hashes[packageId] = Object.fromEntries(
-      fileHashes.map(([fileId, hash]) => [
-        fileId,
-        bytesToHex(new Uint8Array(hash)),
-      ]),
+    hashes[packageId] = writeMemo(
+      packageId,
+      "update",
+      toHashRecord(fileHashes),
     );
   }
   return hashes;
+}
+
+// Download-time twin of the above, for one package. `getFileHashesQuery` is a
+// query (~0.2s) where `getFileHashesByPackageIds` is a consensus update call
+// (~1.5s), and this runs once per package on the install critical path.
+// The registry returns `#err` both for an unknown package and for one whose
+// files are not all hashed; the batch method collapses both to an empty list,
+// so mirror that here — the two paths must classify a package identically.
+async function queryRegistryFileHashes(
+  packageId: string,
+): Promise<Record<string, string>> {
+  let memoized = readMemo(packageId, false);
+  if (memoized) {
+    return memoized;
+  }
+
+  let at = packageId.lastIndexOf("@");
+  if (at <= 0) {
+    return (await fetchRegistryFileHashes([packageId]))[packageId] ?? {};
+  }
+  let name = packageId.slice(0, at);
+  let version = packageId.slice(at + 1);
+
+  let actor = await mainActor();
+  let res = await actor.getFileHashesQuery(name, version);
+  return writeMemo(packageId, "query", "ok" in res ? toHashRecord(res.ok) : {});
+}
+
+// What a query reply told us, before any consensus answer overwrote it.
+function readQuerySourcedMemo(
+  packageId: string,
+): Record<string, string> | undefined {
+  let entry = fileHashesMemo.get(memoKey(packageId));
+  return entry?.source === "query" ? entry.hashes : undefined;
+}
+
+// Every package this process admitted to the cache on a query reply's word,
+// including versions that lost a conflict and so never reach the lock — they
+// are cached all the same, and a later project can install them from there.
+function querySourcedPackageIds(): string[] {
+  let prefix = memoKey("");
+  let packageIds: string[] = [];
+  for (let [key, entry] of fileHashesMemo) {
+    // An empty answer verified nothing, so there is nothing to hold it to.
+    if (
+      entry.source === "query" &&
+      key.startsWith(prefix) &&
+      Object.keys(entry.hashes).length
+    ) {
+      packageIds.push(entry.packageId);
+    }
+  }
+  return packageIds;
+}
+
+// A query reply is signed by one node; a consensus answer, and the lock derived
+// from one, needs 2/3 of the subnet. So a query reply is only ever checked
+// against them, never trusted over them.
+//
+// An *empty* query answer is not a disagreement: the registry reports `#err`
+// (which both hash methods collapse to "no hashes") until every file of a
+// package is hashed, so a node that has not yet seen the admin backfill
+// (`computeHashesForExistingFiles`), or is simply lagging, legitimately answers
+// empty. Nothing was verified against an empty answer either way.
+//
+// Two non-empty answers that differ are another matter: a file hash is written
+// once at publish and never rewritten, and the backfill only fills in file ids
+// that have none, so no legitimate state change can produce one.
+function diffQueryHashes(
+  queried: Record<string, string>,
+  trusted: Record<string, string>,
+  trustedLabel: string,
+): string[] {
+  if (Object.keys(queried).length === 0) {
+    return [];
+  }
+  let problems: string[] = [];
+  for (let fileId of new Set([
+    ...Object.keys(queried),
+    ...Object.keys(trusted),
+  ])) {
+    let queriedHash = queried[fileId];
+    let trustedHash = trusted[fileId];
+    if (queriedHash === trustedHash) {
+      continue;
+    }
+    if (trustedHash === undefined) {
+      problems.push(
+        `${fileId}: in the query response, absent from ${trustedLabel}`,
+      );
+    } else if (queriedHash === undefined) {
+      problems.push(
+        `${fileId}: in ${trustedLabel}, absent from the query response`,
+      );
+    } else {
+      problems.push(
+        `${fileId}: query ${queriedHash}, ${trustedLabel} ${trustedHash}`,
+      );
+    }
+  }
+  return problems;
+}
+
+// Both of the following are deliberately not phrased like an ordinary hash
+// mismatch: that one means the bytes arrived corrupted and a retry may fix it.
+// These mean two records that must agree about an immutable version do not.
+
+// Registry vs. lock. Either record could be the wrong one, so name both causes;
+// the remediation is the same either way. Nothing has entered the global cache
+// at this point — verification runs before the download is staged.
+function describeLockDisagreement(
+  packageId: string,
+  problems: string[],
+): string[] {
+  return [
+    `${packageId}: mops.lock and the registry disagree about the published file hashes`,
+    ...problems.map((problem) => `  ${problem}`),
+    "  A published version is immutable, so one of the two is wrong: either mops.lock is corrupt or hand-edited, or the registry reply was not genuine.",
+    `  ${RESTORE_HINT}`,
+  ];
+}
+
+// Registry vs. itself. Here the lock cannot be at fault — both answers came
+// from the registry, and the weaker of the two is what admitted these bytes to
+// the global cache, so the cached copy has to go.
+function describeConsensusDisagreement(
+  packageId: string,
+  problems: string[],
+): string[] {
+  return [
+    `${packageId}: the registry's query response disagrees with its consensus response`,
+    ...problems.map((problem) => `  ${problem}`),
+    "  A published version is immutable, so the registry cannot legitimately give two answers; this is not a corrupted download and reinstalling will not fix it.",
+    "  The downloaded files were checked against the query response, so the copy now in the global cache cannot be trusted.",
+    "  Run `mops cache clean` before retrying. If it persists, this is a bug in mops or in the registry; please report it.",
+  ];
 }
 
 // Registry packages only — github/path deps have no published file hashes.
@@ -309,26 +542,104 @@ function getMopsTomlHash(): string {
   );
 }
 
-function getMopsTomlDepsHash(): string {
-  let config = readConfig();
-  let deps = config.dependencies || {};
-  let devDeps = config["dev-dependencies"] || {};
-  let allDeps = { ...deps, ...devDeps };
-  // sort allDeps by key
-  let sortedDeps = Object.keys(allDeps)
+function sortedDepValues(
+  deps: Record<string, Dependency>,
+): Record<string, string> {
+  return Object.keys(deps)
     .sort()
     .reduce(
       (acc, key) => {
         acc[key] =
-          allDeps[key]?.version ||
-          allDeps[key]?.repo ||
-          allDeps[key]?.path ||
-          "";
+          deps[key]?.version || deps[key]?.repo || deps[key]?.path || "";
         return acc;
       },
       {} as Record<string, string>,
     );
-  return bytesToHex(sha256(JSON.stringify(sortedDeps)));
+}
+
+function getRootDeclaredDeps(): Record<string, Dependency> {
+  let config = readConfig();
+  return {
+    ...(config.dependencies || {}),
+    ...(config["dev-dependencies"] || {}),
+  };
+}
+
+function getMopsTomlDepsHash(): string {
+  return bytesToHex(
+    sha256(JSON.stringify(sortedDepValues(getRootDeclaredDeps()))),
+  );
+}
+
+function expandMopsEnv(value: string): string {
+  return value.replaceAll("{MOPS_ENV}", process.env.MOPS_ENV || "local");
+}
+
+// `[dependencies]` of every local `path` dependency reachable from the root,
+// keyed by the dep's root-relative directory. Only `[dependencies]`: a nested
+// manifest's dev-dependencies take no part in resolution.
+//
+// `null` marks a directory with no mops.toml, so creating one changes the
+// signature. `{MOPS_ENV}` is expanded into the key, which is what makes the
+// signature environment-specific for the projects that use the placeholder.
+type LocalDepSignature = Record<string, Record<string, string> | string | null>;
+
+function collectLocalDepManifests(
+  rootDir: string,
+  deps: Record<string, Dependency>,
+  configDir: string,
+  visited: Set<string>,
+  signature: LocalDepSignature,
+) {
+  for (let dep of Object.values(deps)) {
+    if (!dep.path) {
+      continue;
+    }
+    let dir = expandMopsEnv(path.resolve(configDir, dep.path));
+    // path deps chain, and can point back at each other
+    if (visited.has(dir)) {
+      continue;
+    }
+    visited.add(dir);
+
+    let key = normalizeLocalDepPath(rootDir, dir);
+    let mopsToml = path.join(dir, "mops.toml");
+    if (!fs.existsSync(mopsToml)) {
+      signature[key] = null;
+      continue;
+    }
+    let nestedDeps: Record<string, Dependency>;
+    try {
+      nestedDeps = readConfig(mopsToml).dependencies || {};
+    } catch {
+      // resolution fails on this manifest too; recorded so that fixing it counts
+      signature[key] = "unreadable";
+      continue;
+    }
+    signature[key] = sortedDepValues(nestedDeps);
+    collectLocalDepManifests(rootDir, nestedDeps, dir, visited, signature);
+  }
+}
+
+// Undefined when the project declares no local path dependency — that absence
+// is what keeps every lock written before this field from being judged stale.
+function getLocalDepsHash(): string | undefined {
+  let signature: LocalDepSignature = {};
+  let rootDir = getRootDir();
+  collectLocalDepManifests(
+    rootDir,
+    getRootDeclaredDeps(),
+    rootDir,
+    new Set(),
+    signature,
+  );
+  let keys = Object.keys(signature).sort();
+  if (!keys.length) {
+    return undefined;
+  }
+  return bytesToHex(
+    sha256(JSON.stringify(keys.map((key) => [key, signature[key]]))),
+  );
 }
 
 // The lock `mops install` would write right now, from a full re-walk of the
@@ -359,12 +670,52 @@ async function computeLockFile(): Promise<LockFileV3> {
       }
     }
   }
+  // Whatever is written into the lock comes from a consensus update call: the
+  // lock is the trust anchor every later check is measured against, so it must
+  // never launder a query reply forward. Every package this process verified
+  // against a query reply rides along in the same batch — one round trip either
+  // way — so nothing that reached the cache escapes the consensus check.
   let missingIds = packageIds.filter((packageId) => !hashes[packageId]);
-  Object.assign(hashes, await fetchRegistryFileHashes(missingIds));
+  let auditIds = [...new Set([...missingIds, ...querySourcedPackageIds()])];
+  // Captured before the fetch, which replaces query memo entries with the
+  // consensus answer.
+  let queried = new Map(
+    auditIds.map((packageId) => [packageId, readQuerySourcedMemo(packageId)]),
+  );
+  let fetched = await fetchRegistryFileHashes(auditIds, {
+    requireConsensus: true,
+  });
+
+  // These packages were admitted to the cache on the strength of the query
+  // answer. This is the moment that answer meets consensus, so it is the moment
+  // a forged one has to die.
+  for (let packageId of auditIds) {
+    let queriedHashes = queried.get(packageId);
+    if (!queriedHashes) {
+      continue;
+    }
+    let problems = diffQueryHashes(
+      queriedHashes,
+      fetched[packageId] ?? {},
+      "consensus",
+    );
+    if (problems.length) {
+      failIntegrity(describeConsensusDisagreement(packageId, problems));
+    }
+  }
+
+  // Only the resolved graph goes into the lock; the audit-only ids do not.
+  for (let packageId of missingIds) {
+    let consensus = fetched[packageId];
+    if (consensus) {
+      hashes[packageId] = consensus;
+    }
+  }
 
   return {
     version: CURRENT_LOCK_VERSION,
     mopsTomlDepsHash: getMopsTomlDepsHash(),
+    localDepsHash: getLocalDepsHash(),
     deps: resolvedDeps,
     graph,
     hashes,
@@ -407,7 +758,7 @@ export async function updateLockFile({
   return true;
 }
 
-function failLocked(lines: string[]): never {
+function failIntegrity(lines: string[]): never {
   console.error("Error: " + lines[0]);
   for (let line of lines.slice(1)) {
     console.error(line);
@@ -460,6 +811,12 @@ function describeLockDefect(defect: LockDefect): string[] {
         `  Actual dependencies hash: ${defect.actual}`,
         REGENERATE_HINT,
       ];
+    case "local-deps-hash":
+      return [
+        "mops.lock does not match the local `path` dependencies, but --locked was passed.",
+        "  A path dependency's mops.toml has changed, or MOPS_ENV differs from the one mops.lock was generated with.",
+        REGENERATE_HINT,
+      ];
     case "absolute-paths":
       return [
         "mops.lock records machine-specific absolute paths for local dependencies, but --locked was passed.",
@@ -486,14 +843,14 @@ function describeLockDefect(defect: LockDefect): string[] {
 export function checkLockedPrerequisites(): void {
   let defect = inspectLockFile();
   if (defect) {
-    failLocked(describeLockDefect(defect));
+    failIntegrity(describeLockDefect(defect));
   }
 }
 
 // Every dependency declared in mops.toml must be pinned to that same value in
 // the lock. Pure and offline, so `--locked` can run it before downloading
-// anything. Local `path` deps are skipped: resolution normalizes them and they
-// point at live directories by design.
+// anything. Local `path` deps are skipped here — resolution normalizes and
+// env-expands them, so they are covered by `localDepsHash` instead.
 function checkLockedDeps(lock: LockFileV3): string[] {
   let problems: string[] = [];
   let config = readConfig();
@@ -525,11 +882,12 @@ function checkLockedDeps(lock: LockFileV3): string[] {
 //   2. the `deps` and `hashes` maps agree on the set of registry packages
 //   3. every file hash in `hashes` matches the registry
 //
-// Together with the `mopsTomlDepsHash` check this catches the realistic drift
-// (an edited mops.toml, a hand-edited or stale lock) plus lock tampering.
-// Published versions are immutable, so a transitive version cannot change
-// underneath a lock. Not caught: transitive drift of local `path` dependencies,
-// which are live directories by design and carry no hashes.
+// Together with the `mopsTomlDepsHash` / `localDepsHash` checks this catches the
+// realistic drift (an edited mops.toml, an edited local dependency's manifest, a
+// hand-edited or stale lock) plus lock tampering. Published versions are
+// immutable, so a transitive version cannot change underneath a lock. Not
+// caught: the *file contents* of a local `path` dependency, which is a live
+// directory by design and carries no hashes.
 async function checkLockConsistency(lock: LockFileV3): Promise<string[]> {
   let problems = checkLockedDeps(lock);
 
@@ -547,7 +905,9 @@ async function checkLockConsistency(lock: LockFileV3): Promise<string[]> {
     }
   }
 
-  let registryHashes = await fetchRegistryFileHashes(packageIds);
+  let registryHashes = await fetchRegistryFileHashes(packageIds, {
+    requireConsensus: true,
+  });
   for (let packageId of packageIds) {
     let lockedFiles = lock.hashes[packageId];
     let registryFiles = registryHashes[packageId];
@@ -600,7 +960,7 @@ export async function assertLockedUpToDate(): Promise<void> {
     // prerequisites, so reaching here means the recorded file hashes disagree
     // with the registry — which install will not rewrite. Give the hint that
     // actually recovers, not the one that loops.
-    failLocked([
+    failIntegrity([
       "mops.lock does not match the registry, but --locked was passed.",
       ...problems.map((problem) => `  ${problem}`),
       RESTORE_HINT,
@@ -622,13 +982,35 @@ export async function verifyDownloadedPackageFiles(
   packageId: string,
   filesData: Map<string, ArrayLike<number>>,
 ): Promise<DownloadVerification> {
-  let registryHashes = (await fetchRegistryFileHashes([packageId]))[packageId];
+  let queriedHashes = await queryRegistryFileHashes(packageId);
+
+  // A committed lock already records this package's hashes from a consensus
+  // call, so where it covers the package it outranks the query reply — and a
+  // reply that contradicts it is reported instead of trusted. This is also what
+  // catches a forged query on the common path, where the lock is current and
+  // `computeLockFile` (which does the same check against consensus) never runs.
+  let lockedHashes = readLockFile()?.hashes[packageId] ?? {};
+  if (Object.keys(lockedHashes).length) {
+    let problems = diffQueryHashes(queriedHashes, lockedHashes, "mops.lock");
+    if (problems.length) {
+      return {
+        errors: describeLockDisagreement(packageId, problems),
+        unverified: false,
+      };
+    }
+  }
+
+  // Equal by the check above whenever both are populated; the fallback matters
+  // when the query node has not caught up with the hashes the lock already has.
+  let registryHashes = Object.keys(queriedHashes).length
+    ? queriedHashes
+    : lockedHashes;
 
   // The registry derives its hash list from the same file-id set it serves for
   // download, and collapses a partially-hashed package to an empty list, so
   // this is all-or-nothing: either every file is checkable or none is. Old
   // packages predating recorded hashes fall in the latter bucket.
-  if (!registryHashes || Object.keys(registryHashes).length === 0) {
+  if (Object.keys(registryHashes).length === 0) {
     return { errors: [], unverified: true };
   }
 
@@ -653,7 +1035,8 @@ export async function verifyDownloadedPackageFiles(
       );
       continue;
     }
-    let actualHash = bytesToHex(sha256(Uint8Array.from(data)));
+    let bytes = data instanceof Uint8Array ? data : Uint8Array.from(data);
+    let actualHash = bytesToHex(sha256(bytes));
     if (actualHash !== expectedHash) {
       errors.push(
         `Hash mismatch for ${prefix}${filePath}\n  Expected: ${expectedHash}\n  Actual:   ${actualHash}`,
@@ -733,6 +1116,16 @@ export async function verifyIntegrity(): Promise<VerifyResult> {
       "mops.toml has changed since mops.lock was generated.",
       `  Locked dependencies hash: ${lock.mopsTomlDepsHash}`,
       `  Actual dependencies hash: ${getMopsTomlDepsHash()}`,
+    );
+  }
+
+  if (
+    lock.version === CURRENT_LOCK_VERSION &&
+    lock.localDepsHash !== getLocalDepsHash()
+  ) {
+    errors.push(
+      "A local `path` dependency's mops.toml has changed since mops.lock was generated, or MOPS_ENV differs.",
+      "  Run `mops install` to update mops.lock, then commit it.",
     );
   }
 

--- a/cli/notify-installs.ts
+++ b/cli/notify-installs.ts
@@ -1,5 +1,5 @@
 import { getDependencyType } from "./mops.js";
-import { mainActor } from "./api/actors.js";
+import { mainOnewayCall } from "./api/actors.js";
 import { getDepName } from "./helpers/get-dep-name.js";
 
 export async function notifyInstalls(installedDeps: Record<string, string>) {
@@ -8,10 +8,8 @@ export async function notifyInstalls(installedDeps: Record<string, string>) {
     .map(([name, version]) => [getDepName(name), version] as [string, string]);
 
   if (packages.length) {
-    let actor = await mainActor();
-
     try {
-      await actor.notifyInstalls(packages);
+      await mainOnewayCall("notifyInstalls", [packages]);
     } catch (err) {
       // console.error('Failed to notify installs:', err);
     }

--- a/cli/resolve-packages.ts
+++ b/cli/resolve-packages.ts
@@ -1,7 +1,9 @@
 import process from "node:process";
 import path from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import chalk from "chalk";
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
 import {
   checkConfigFile,
   getRootDir,
@@ -48,6 +50,55 @@ export async function resolvePackages({ skipLock = false } = {}): Promise<
   return (await resolveDepsAndGraph({ skipLock })).deps;
 }
 
+type ResolveResult = {
+  deps: Record<string, string>;
+  graph: Record<string, Record<string, string>>;
+};
+
+// In-process only, never written to disk. A single command resolves 3-5 times
+// and rewrites its own inputs while doing so — checkIntegrity writes mops.lock,
+// add/remove/update write mops.toml — so the key is the *content* of both, not
+// their paths. Local `path` deps are live directories, so their manifests are
+// validated too (see `localInputs`).
+type ResolveCacheEntry = {
+  key: string;
+  promise: Promise<ResolveResult>;
+  // Local manifests the walk read; unknown until it finishes.
+  localInputs: Map<string, string> | null;
+};
+
+let resolveCache: ResolveCacheEntry | null = null;
+
+// "" for a file that does not exist, so creating or deleting one invalidates.
+function fileHash(file: string): string {
+  try {
+    return bytesToHex(sha256(readFileSync(file)));
+  } catch {
+    return "";
+  }
+}
+
+// `skipLock` is keyed by what it changes, not by its value: it only suppresses
+// the lock short-circuit, so with no usable lock the two variants walk the same
+// graph. That is what lets a cold install's two resolves (sync, then lock
+// regeneration) share one walk.
+function resolveCacheKey(rootDir: string, usesLock: boolean): string {
+  return [
+    rootDir,
+    usesLock,
+    conflictPolicy,
+    process.env.MOPS_ENV || "",
+    fileHash(path.join(rootDir, "mops.toml")),
+    fileHash(path.join(rootDir, "mops.lock")),
+  ].join("|");
+}
+
+// Callers iterate and (in the lock's case) embed the result, so hand out a copy
+// rather than the memoized object itself.
+function copyResult(result: ResolveResult): ResolveResult {
+  return { deps: { ...result.deps }, graph: { ...result.graph } };
+}
+
 // Resolves winners and collects the declared dependency edges of every
 // registry package version visited (losers included), so the lock can be
 // regenerated later without those versions on disk.
@@ -55,15 +106,50 @@ export async function resolveDepsAndGraph({
   // Bypass a valid lock so lock regeneration re-reads mops.toml (this is how
   // absolute local paths from older CLIs get rewritten root-relative).
   skipLock = false,
-} = {}): Promise<{
-  deps: Record<string, string>;
-  graph: Record<string, Record<string, string>>;
-}> {
+} = {}): Promise<ResolveResult> {
   if (!checkConfigFile()) {
     return { deps: {}, graph: {} };
   }
 
-  if (!skipLock && checkLockFileLight()) {
+  let rootDir = getRootDir();
+  let usesLock = !skipLock && checkLockFileLight();
+  let key = resolveCacheKey(rootDir, usesLock);
+  let cached = resolveCache;
+  if (
+    cached &&
+    cached.key === key &&
+    (cached.localInputs === null ||
+      [...cached.localInputs].every(([file, hash]) => fileHash(file) === hash))
+  ) {
+    return copyResult(await cached.promise);
+  }
+
+  let localInputs = new Map<string, string>();
+  let entry: ResolveCacheEntry = {
+    key,
+    localInputs: null,
+    promise: resolveDepsAndGraphUncached(usesLock, rootDir, localInputs),
+  };
+  resolveCache = entry;
+
+  try {
+    let result = await entry.promise;
+    entry.localInputs = localInputs;
+    return copyResult(result);
+  } catch (err) {
+    if (resolveCache === entry) {
+      resolveCache = null;
+    }
+    throw err;
+  }
+}
+
+async function resolveDepsAndGraphUncached(
+  usesLock: boolean,
+  rootDir: string,
+  localInputs: Map<string, string>,
+): Promise<ResolveResult> {
+  if (usesLock) {
     let lockFileJson = readLockFile();
 
     if (lockFileJson && lockFileJson.version === 3) {
@@ -77,7 +163,6 @@ export async function resolveDepsAndGraph({
   let lockGraph = readLockFileGraph();
   let graph: Record<string, Record<string, string>> = {};
 
-  let rootDir = getRootDir();
   let packages: Record<string, Dependency & { isRoot: boolean }> = {};
   let versions: Record<
     string,
@@ -157,6 +242,8 @@ export async function resolveDepsAndGraph({
           .resolve(configDir, pkgDetails.path)
           .replaceAll("{MOPS_ENV}", process.env.MOPS_ENV || "local");
         let mopsToml = path.join(localNestedDir, "mops.toml");
+        // recorded even when absent: creating one changes the resolution
+        localInputs.set(mopsToml, fileHash(mopsToml));
         if (existsSync(mopsToml)) {
           nestedConfig = readConfig(mopsToml);
         }

--- a/cli/tests/cache-clean.test.ts
+++ b/cli/tests/cache-clean.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// `api/actors` pulls in the generated `*.did.js` declarations, which the ESM
+// `.js` -> extensionless moduleNameMapper resolves to the raw `.did` files.
+jest.unstable_mockModule("../api/actors.js", () => ({
+  mainActor: jest.fn(),
+  mainOnewayCall: jest.fn(),
+  storageActor: jest.fn(),
+}));
+
+// `mops.ts` derives `globalCacheDir` at import time.
+const cacheHome = fs.realpathSync(
+  fs.mkdtempSync(path.join(os.tmpdir(), "mops-cache-clean-")),
+);
+process.env["XDG_CACHE_HOME"] = cacheHome;
+
+const { assertGlobalCacheDir, cleanCache, show } = await import("../cache.js");
+
+const posixCache = "/home/u/.cache/mops";
+const macCache = "/Users/u/Library/Caches/mops";
+// `path.join` yields backslashes on Windows, which the old `endsWith("mops/cache")`
+// guard could never match — `mops cache clean` threw there unconditionally.
+const winCache = "C:\\Users\\u\\AppData\\Local\\mops\\cache";
+
+describe("assertGlobalCacheDir", () => {
+  afterEach(() => {
+    delete process.env["MOPS_NETWORK"];
+  });
+
+  test("accepts the cache dir on every platform layout", () => {
+    expect(() => assertGlobalCacheDir(posixCache, posixCache)).not.toThrow();
+    expect(() => assertGlobalCacheDir(macCache, macCache)).not.toThrow();
+    expect(() => assertGlobalCacheDir(winCache, winCache)).not.toThrow();
+  });
+
+  test("accepts the network-scoped cache dir", () => {
+    process.env["MOPS_NETWORK"] = "local";
+    expect(() =>
+      assertGlobalCacheDir(posixCache + "/local", posixCache),
+    ).not.toThrow();
+    expect(() =>
+      assertGlobalCacheDir(winCache + "\\local", winCache),
+    ).not.toThrow();
+  });
+
+  test("rejects a network segment that is not the current network", () => {
+    expect(() =>
+      assertGlobalCacheDir(posixCache + "/local", posixCache),
+    ).toThrow(/Invalid cache directory/);
+  });
+
+  test("rejects anything but the cache root", () => {
+    expect(() =>
+      assertGlobalCacheDir(posixCache + "/packages", posixCache),
+    ).toThrow(/Invalid cache directory/);
+    expect(() => assertGlobalCacheDir("/home/u/.cache", posixCache)).toThrow(
+      /Invalid cache directory/,
+    );
+    expect(() => assertGlobalCacheDir("/tmp/something", posixCache)).toThrow(
+      /Invalid cache directory/,
+    );
+  });
+
+  test("rejects a traversing network name", () => {
+    process.env["MOPS_NETWORK"] = "../..";
+    expect(() =>
+      assertGlobalCacheDir(path.join(posixCache, "../.."), posixCache),
+    ).toThrow(/Invalid cache directory/);
+  });
+});
+
+describe("cleanCache", () => {
+  const seed = () => {
+    let globalCache = show();
+    fs.mkdirSync(path.join(globalCache, "packages", "core@1.0.0"), {
+      recursive: true,
+    });
+
+    let project = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "mops-project-")),
+    );
+    fs.writeFileSync(path.join(project, "mops.toml"), "[dependencies]\n");
+    fs.mkdirSync(path.join(project, ".mops", "core@1.0.0"), {
+      recursive: true,
+    });
+    return { globalCache, project };
+  };
+
+  const inProject = async (project: string, fn: () => Promise<void>) => {
+    let cwd = process.cwd();
+    process.chdir(project);
+    try {
+      await fn();
+    } finally {
+      process.chdir(cwd);
+    }
+  };
+
+  test("removes the global cache and the project's .mops", async () => {
+    let { globalCache, project } = seed();
+    await inProject(project, () => cleanCache());
+    expect(fs.existsSync(globalCache)).toBe(false);
+    expect(fs.existsSync(path.join(project, ".mops"))).toBe(false);
+  });
+
+  test("global keeps the project's .mops", async () => {
+    let { globalCache, project } = seed();
+    await inProject(project, () => cleanCache({ global: true }));
+    expect(fs.existsSync(globalCache)).toBe(false);
+    expect(fs.existsSync(path.join(project, ".mops", "core@1.0.0"))).toBe(true);
+  });
+});

--- a/cli/tests/download-path.test.ts
+++ b/cli/tests/download-path.test.ts
@@ -1,0 +1,661 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
+import fs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
+
+// The registry actor and dependency resolution are the only things these tests
+// fake; everything else is the real code path. Mocked before importing the
+// modules under test, as ESM requires.
+type HashEntry = [string, Uint8Array];
+type QueryResult = { ok: HashEntry[] } | { err: string };
+
+let queryCalls: Array<[string, string]> = [];
+let batchCalls: string[][] = [];
+const queryResponses = new Map<string, QueryResult>();
+// Only set where a test needs the update call to answer differently from the
+// query call; otherwise the two registry methods agree, as they must.
+const batchResponses = new Map<string, HashEntry[]>();
+let resolvedDeps: Record<string, string> = {};
+
+const actor = {
+  getFileHashesQuery: async (name: string, version: string) => {
+    queryCalls.push([name, version]);
+    return queryResponses.get(`${name}@${version}`) ?? { err: "not found" };
+  },
+  getFileHashesByPackageIds: async (packageIds: string[]) => {
+    batchCalls.push(packageIds);
+    return packageIds.map((packageId) => {
+      let override = batchResponses.get(packageId);
+      if (override) {
+        return [packageId, override] as [string, HashEntry[]];
+      }
+      let res = queryResponses.get(packageId);
+      return [packageId, res && "ok" in res ? res.ok : []] as [
+        string,
+        HashEntry[],
+      ];
+    });
+  },
+};
+
+jest.unstable_mockModule("../api/actors.js", () => ({
+  mainActor: async () => actor,
+  storageActor: async () => {
+    throw new Error("storageActor should not be used in these tests");
+  },
+}));
+
+jest.unstable_mockModule("../resolve-packages.js", () => ({
+  resolveDepsAndGraph: async () => ({ deps: resolvedDeps, graph: {} }),
+}));
+
+const { verifyDownloadedPackageFiles, updateLockFile } =
+  await import("../integrity.js");
+const { downloadFile } = await import("../api/downloadPackageFiles.js");
+
+const bytes = (text: string) => new TextEncoder().encode(text);
+const hashOf = (text: string) => bytesToHex(sha256(bytes(text)));
+
+// Each test uses its own package id: the hash memo is per-process and has no
+// reset hook by design, so isolation comes from distinct keys.
+let counter = 0;
+const uniqueId = () => `pkg${counter++}@1.0.0`;
+
+// The lock is found by walking up from cwd, so a temp project is the only way
+// to exercise the real `readLockFile` path.
+async function inTempProject<T>(
+  {
+    lock,
+    deps = {},
+  }: { lock?: unknown; deps?: Record<string, { version: string }> },
+  fn: (dir: string) => Promise<T>,
+): Promise<T> {
+  let dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "mops-integrity-"));
+  let dependencies = Object.entries(deps)
+    .map(([name, dep]) => `${name} = "${dep.version}"`)
+    .join("\n");
+  fs.writeFileSync(
+    nodePath.join(dir, "mops.toml"),
+    `[package]\nname = "t"\nversion = "0.1.0"\n\n[dependencies]\n${dependencies}\n`,
+  );
+  if (lock) {
+    fs.writeFileSync(
+      nodePath.join(dir, "mops.lock"),
+      JSON.stringify(lock, null, 2),
+    );
+  }
+  let cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    return await fn(dir);
+  } finally {
+    process.chdir(cwd);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const lockWith = (packageId: string, hashes: Record<string, string>) => ({
+  version: 3,
+  mopsTomlDepsHash: "stale",
+  deps: { [packageId.split("@")[0] as string]: "1.0.0" },
+  hashes: { [packageId]: hashes },
+});
+
+// Only the call logs reset between tests. The registry keeps answering for
+// every package id it has already served, because lock generation audits every
+// package the process fetched by query — package ids are unique per test, so
+// the responses never collide.
+beforeEach(() => {
+  queryCalls = [];
+  batchCalls = [];
+  resolvedDeps = {};
+});
+
+// Minimal stand-in for the storage canister actor.
+function fakeStorage({
+  chunks,
+  path = "src/lib.mo",
+  chunkCount,
+  metaErr,
+  onCall,
+}: {
+  chunks: string[];
+  path?: string;
+  chunkCount?: bigint;
+  metaErr?: string;
+  onCall?: (method: string) => void;
+}) {
+  let calls: string[] = [];
+  let storage = {
+    getFileMeta: async (fileId: string) => {
+      calls.push("getFileMeta");
+      onCall?.("getFileMeta");
+      if (metaErr) {
+        return { err: metaErr };
+      }
+      return {
+        ok: {
+          id: fileId,
+          owners: [],
+          path,
+          chunkCount: chunkCount ?? BigInt(chunks.length),
+        },
+      };
+    },
+    downloadChunk: async (fileId: string, index: bigint) => {
+      calls.push(`downloadChunk:${index}`);
+      onCall?.(`downloadChunk:${index}`);
+      let chunk = chunks[Number(index)];
+      if (chunk === undefined) {
+        return { err: `Invalid chunk index '${index}' for file '${fileId}'` };
+      }
+      return { ok: Array.from(bytes(chunk)) };
+    },
+  };
+  return { storage, calls };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const asStorage = (storage: unknown) => storage as any;
+
+describe("downloadFile", () => {
+  test("fetches meta and chunk 0 concurrently for a single-chunk file", async () => {
+    // getFileMeta cannot resolve until downloadChunk has been called, so this
+    // deadlocks if the two calls are chained instead of issued together.
+    let chunkRequested: () => void;
+    let chunkRequestedPromise = new Promise<void>((resolve) => {
+      chunkRequested = resolve;
+    });
+    let { storage, calls } = fakeStorage({
+      chunks: ["module {}"],
+      onCall: (method) => {
+        if (method === "downloadChunk:0") {
+          chunkRequested();
+        }
+      },
+    });
+    let getFileMeta = storage.getFileMeta;
+    storage.getFileMeta = async (fileId: string) => {
+      await chunkRequestedPromise;
+      return getFileMeta(fileId);
+    };
+
+    let { path, data } = await downloadFile(
+      asStorage(storage),
+      "core@1/lib.mo",
+    );
+
+    expect(calls).toEqual(["downloadChunk:0", "getFileMeta"]);
+    expect(path).toBe("src/lib.mo");
+    expect(data).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(data)).toBe("module {}");
+  });
+
+  test("concatenates multiple chunks in order", async () => {
+    let { storage, calls } = fakeStorage({ chunks: ["aaa", "bbb", "ccc"] });
+
+    let { data } = await downloadFile(asStorage(storage), "core@1/lib.mo");
+
+    expect(new TextDecoder().decode(data)).toBe("aaabbbccc");
+    expect(calls).toEqual([
+      "getFileMeta",
+      "downloadChunk:0",
+      "downloadChunk:1",
+      "downloadChunk:2",
+    ]);
+  });
+
+  test("an empty file has no chunks and the speculative chunk error is ignored", async () => {
+    let { storage } = fakeStorage({ chunks: [], chunkCount: 0n });
+
+    let { data } = await downloadFile(asStorage(storage), "core@1/empty.mo");
+
+    expect(data).toEqual(new Uint8Array());
+  });
+
+  test("a missing file reports the meta error, not the chunk error", async () => {
+    let { storage } = fakeStorage({
+      chunks: [],
+      metaErr: "File 'core@1/nope.mo' not found",
+    });
+
+    await expect(
+      downloadFile(asStorage(storage), "core@1/nope.mo"),
+    ).rejects.toBe("File 'core@1/nope.mo' not found");
+  });
+
+  test("a rejecting meta call does not leave the chunk rejection unhandled", async () => {
+    let unhandled: unknown[] = [];
+    let onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    let storage = {
+      getFileMeta: async () => {
+        throw new Error("fetch failed");
+      },
+      downloadChunk: async () => {
+        throw new Error("fetch failed");
+      },
+    };
+
+    try {
+      await expect(
+        downloadFile(asStorage(storage), "core@1/lib.mo"),
+      ).rejects.toThrow("fetch failed");
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  test("a chunk error past chunk 0 aborts the download", async () => {
+    let storage = {
+      getFileMeta: async () => ({
+        ok: { id: "f", owners: [], path: "lib.mo", chunkCount: 3n },
+      }),
+      downloadChunk: async (_fileId: string, index: bigint) =>
+        index === 0n ? { ok: [1, 2, 3] } : { err: "chunk gone" },
+    };
+
+    await expect(
+      downloadFile(asStorage(storage), "core@1/lib.mo"),
+    ).rejects.toBe("chunk gone");
+  });
+});
+
+describe("verifyDownloadedPackageFiles", () => {
+  test("verifies via the query method, not the batch update call", async () => {
+    let packageId = uniqueId();
+    queryResponses.set(packageId, {
+      ok: [[`${packageId}/src/lib.mo`, sha256(bytes("module {}"))]],
+    });
+
+    let result = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module {}")]]),
+    );
+
+    expect(result).toEqual({ errors: [], unverified: false });
+    expect(queryCalls).toEqual([packageId.split("@")]);
+    expect(batchCalls).toEqual([]);
+  });
+
+  test("a mismatched hash is an error", async () => {
+    let packageId = uniqueId();
+    queryResponses.set(packageId, {
+      ok: [[`${packageId}/src/lib.mo`, sha256(bytes("module {}"))]],
+    });
+
+    let result = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module { let evil = 1 }")]]),
+    );
+
+    expect(result.unverified).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/Hash mismatch for .*src\/lib\.mo/);
+    expect(result.errors[0]).toContain(hashOf("module {}"));
+  });
+
+  test("a missing file is an error", async () => {
+    let packageId = uniqueId();
+    queryResponses.set(packageId, {
+      ok: [
+        [`${packageId}/src/lib.mo`, sha256(bytes("module {}"))],
+        [`${packageId}/mops.toml`, sha256(bytes("[package]"))],
+      ],
+    });
+
+    let result = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module {}")]]),
+    );
+
+    expect(result.errors).toEqual([
+      `Missing file ${packageId}/mops.toml in downloaded package`,
+    ]);
+  });
+
+  test("an unexpected extra file is an error", async () => {
+    let packageId = uniqueId();
+    queryResponses.set(packageId, {
+      ok: [[`${packageId}/src/lib.mo`, sha256(bytes("module {}"))]],
+    });
+
+    let result = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([
+        ["src/lib.mo", bytes("module {}")],
+        ["src/backdoor.mo", bytes("module {}")],
+      ]),
+    );
+
+    expect(result.errors).toEqual([
+      `Unexpected file src/backdoor.mo is not published in ${packageId}`,
+    ]);
+  });
+
+  test("a registry file id from another package is an error", async () => {
+    let packageId = uniqueId();
+    queryResponses.set(packageId, {
+      ok: [["other@1.0.0/src/lib.mo", sha256(bytes("module {}"))]],
+    });
+
+    let result = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module {}")]]),
+    );
+
+    expect(result.unverified).toBe(false);
+    expect(result.errors).toContain(
+      `Registry file other@1.0.0/src/lib.mo does not belong to package ${packageId}`,
+    );
+  });
+
+  test("an #err reply means unverified, matching the batch method's empty list", async () => {
+    let packageId = uniqueId();
+    queryResponses.set(packageId, { err: "File hash not found for x" });
+
+    let result = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module {}")]]),
+    );
+
+    expect(result).toEqual({ errors: [], unverified: true });
+  });
+
+  test("an empty hash list means unverified", async () => {
+    let packageId = uniqueId();
+    queryResponses.set(packageId, { ok: [] });
+
+    let result = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module {}")]]),
+    );
+
+    expect(result).toEqual({ errors: [], unverified: true });
+  });
+
+  test("a query reply that contradicts mops.lock is refused, not trusted", async () => {
+    let packageId = uniqueId();
+    let fileId = `${packageId}/src/lib.mo`;
+    // the query response matches the bytes on offer, so plain verification
+    // would pass; only the lock reveals that they are not what was published
+    queryResponses.set(packageId, {
+      ok: [[fileId, sha256(bytes("module { let evil = 1 }"))]],
+    });
+
+    let result = await inTempProject(
+      { lock: lockWith(packageId, { [fileId]: hashOf("module {}") }) },
+      () =>
+        verifyDownloadedPackageFiles(
+          packageId,
+          new Map([["src/lib.mo", bytes("module { let evil = 1 }")]]),
+        ),
+    );
+
+    expect(result.unverified).toBe(false);
+    expect(result.errors[0]).toBe(
+      `${packageId}: mops.lock and the registry disagree about the published file hashes`,
+    );
+    expect(result.errors[1]).toBe(
+      `  ${fileId}: query ${hashOf("module { let evil = 1 }")}, mops.lock ${hashOf("module {}")}`,
+    );
+    expect(result.errors.join("\n")).toMatch(/Restore mops\.lock/);
+    // reported as a disagreement, not as a corrupted download
+    expect(result.errors.join("\n")).not.toMatch(/Hash mismatch/);
+  });
+
+  test("a query reply claiming a file mops.lock does not have is refused", async () => {
+    let packageId = uniqueId();
+    let fileId = `${packageId}/src/lib.mo`;
+    let extraId = `${packageId}/src/extra.mo`;
+    queryResponses.set(packageId, {
+      ok: [
+        [fileId, sha256(bytes("module {}"))],
+        [extraId, sha256(bytes("module {}"))],
+      ],
+    });
+
+    let result = await inTempProject(
+      { lock: lockWith(packageId, { [fileId]: hashOf("module {}") }) },
+      () =>
+        verifyDownloadedPackageFiles(
+          packageId,
+          new Map([
+            ["src/lib.mo", bytes("module {}")],
+            ["src/extra.mo", bytes("module {}")],
+          ]),
+        ),
+    );
+
+    expect(result.errors[1]).toBe(
+      `  ${extraId}: in the query response, absent from mops.lock`,
+    );
+  });
+
+  test("an empty query reply falls back to mops.lock rather than passing unverified", async () => {
+    let packageId = uniqueId();
+    let fileId = `${packageId}/src/lib.mo`;
+    // the admin hash backfill has not reached this node yet
+    queryResponses.set(packageId, { err: "File hash not found for x" });
+    let lock = lockWith(packageId, { [fileId]: hashOf("module {}") });
+
+    let good = await inTempProject({ lock }, () =>
+      verifyDownloadedPackageFiles(
+        packageId,
+        new Map([["src/lib.mo", bytes("module {}")]]),
+      ),
+    );
+    expect(good).toEqual({ errors: [], unverified: false });
+
+    let bad = await inTempProject({ lock }, () =>
+      verifyDownloadedPackageFiles(
+        packageId,
+        new Map([["src/lib.mo", bytes("module { let evil = 1 }")]]),
+      ),
+    );
+    expect(bad.errors[0]).toMatch(/Hash mismatch/);
+  });
+
+  test("a lock that agrees leaves ordinary verification untouched", async () => {
+    let packageId = uniqueId();
+    let fileId = `${packageId}/src/lib.mo`;
+    queryResponses.set(packageId, {
+      ok: [[fileId, sha256(bytes("module {}"))]],
+    });
+    let lock = lockWith(packageId, { [fileId]: hashOf("module {}") });
+
+    let good = await inTempProject({ lock }, () =>
+      verifyDownloadedPackageFiles(
+        packageId,
+        new Map([["src/lib.mo", bytes("module {}")]]),
+      ),
+    );
+    expect(good).toEqual({ errors: [], unverified: false });
+
+    let bad = await inTempProject({ lock }, () =>
+      verifyDownloadedPackageFiles(
+        packageId,
+        new Map([["src/lib.mo", bytes("module { let evil = 1 }")]]),
+      ),
+    );
+    expect(bad.errors).toHaveLength(1);
+    expect(bad.errors[0]).toMatch(/Hash mismatch/);
+  });
+
+  test("hashes are fetched once per package per process", async () => {
+    let packageId = uniqueId();
+    queryResponses.set(packageId, {
+      ok: [[`${packageId}/src/lib.mo`, sha256(bytes("module {}"))]],
+    });
+    let filesData = new Map([["src/lib.mo", bytes("module {}")]]);
+
+    await verifyDownloadedPackageFiles(packageId, filesData);
+    await verifyDownloadedPackageFiles(packageId, filesData);
+
+    expect(queryCalls).toHaveLength(1);
+    expect(batchCalls).toEqual([]);
+
+    // the memo must not turn a later mismatch into a pass
+    let mismatch = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module { let evil = 1 }")]]),
+    );
+    expect(mismatch.errors).toHaveLength(1);
+  });
+});
+
+// `updateLockFile` -> `computeLockFile` is where a package downloaded on the
+// strength of a query reply first meets a consensus answer, and there is no
+// lock yet to have caught it earlier.
+describe("lockfile generation", () => {
+  const runUpdateLockFile = async (packageId: string) => {
+    let name = packageId.split("@")[0] as string;
+    resolvedDeps = { [name]: "1.0.0" };
+    let errors: string[] = [];
+    let consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation((...args: unknown[]) => {
+        errors.push(args.join(" "));
+      });
+    let exit = jest.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    try {
+      let thrown: unknown;
+      await inTempProject(
+        { deps: { [name]: { version: "1.0.0" } } },
+        async () => {
+          try {
+            await updateLockFile({ silent: true });
+          } catch (err) {
+            thrown = err;
+          }
+        },
+      );
+      return { errors, thrown };
+    } finally {
+      consoleError.mockRestore();
+      exit.mockRestore();
+    }
+  };
+
+  test("writes consensus hashes, not the query hashes it already has", async () => {
+    let packageId = `agree${counter++}@1.0.0`;
+    let fileId = `${packageId}/src/lib.mo`;
+    queryResponses.set(packageId, {
+      ok: [[fileId, sha256(bytes("module {}"))]],
+    });
+
+    // prime the memo the way a download does
+    await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module {}")]]),
+    );
+    expect(batchCalls).toEqual([]);
+
+    let { thrown } = await runUpdateLockFile(packageId);
+
+    expect(thrown).toBeUndefined();
+    // the query memo did not satisfy lock generation
+    expect(batchCalls).toHaveLength(1);
+    expect(batchCalls[0]).toContain(packageId);
+  });
+
+  test("a package downloaded against forged query hashes dies at lock time", async () => {
+    let packageId = `forged${counter++}@1.0.0`;
+    let fileId = `${packageId}/src/lib.mo`;
+    queryResponses.set(packageId, {
+      ok: [[fileId, sha256(bytes("module { let evil = 1 }"))]],
+    });
+    batchResponses.set(packageId, [[fileId, sha256(bytes("module {}"))]]);
+
+    // the forged bytes pass download verification against the forged reply
+    let download = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module { let evil = 1 }")]]),
+    );
+    expect(download).toEqual({ errors: [], unverified: false });
+
+    let { errors, thrown } = await runUpdateLockFile(packageId);
+
+    expect(thrown).toEqual(new Error("process.exit(1)"));
+    expect(errors[0]).toBe(
+      `Error: ${packageId}: the registry's query response disagrees with its consensus response`,
+    );
+    expect(errors[1]).toBe(
+      `  ${fileId}: query ${hashOf("module { let evil = 1 }")}, consensus ${hashOf("module {}")}`,
+    );
+    expect(errors.join("\n")).toMatch(/mops cache clean/);
+  });
+
+  test("a query reply claiming hashes the registry does not have dies at lock time", async () => {
+    let packageId = `phantom${counter++}@1.0.0`;
+    let fileId = `${packageId}/src/lib.mo`;
+    queryResponses.set(packageId, {
+      ok: [[fileId, sha256(bytes("module {}"))]],
+    });
+    // consensus says this package has no recorded hashes at all
+    batchResponses.set(packageId, []);
+
+    await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module {}")]]),
+    );
+
+    let { errors, thrown } = await runUpdateLockFile(packageId);
+
+    expect(thrown).toEqual(new Error("process.exit(1)"));
+    expect(errors[1]).toBe(
+      `  ${fileId}: in the query response, absent from consensus`,
+    );
+  });
+
+  test("a downloaded package that never reaches the lock is audited too", async () => {
+    // a version that lost a conflict: cached, but absent from the resolved graph
+    let loserId = `loser${counter++}@1.0.0`;
+    let loserFileId = `${loserId}/src/lib.mo`;
+    queryResponses.set(loserId, {
+      ok: [[loserFileId, sha256(bytes("module { let evil = 1 }"))]],
+    });
+    batchResponses.set(loserId, [[loserFileId, sha256(bytes("module {}"))]]);
+    await verifyDownloadedPackageFiles(
+      loserId,
+      new Map([["src/lib.mo", bytes("module { let evil = 1 }")]]),
+    );
+
+    let winnerId = `winner${counter++}@1.0.0`;
+    queryResponses.set(winnerId, {
+      ok: [[`${winnerId}/src/lib.mo`, sha256(bytes("module {}"))]],
+    });
+
+    let { errors, thrown } = await runUpdateLockFile(winnerId);
+
+    expect(thrown).toEqual(new Error("process.exit(1)"));
+    expect(errors[0]).toContain(loserId);
+  });
+
+  test("a query node that has not seen the hash backfill is not a disagreement", async () => {
+    let packageId = `lagging${counter++}@1.0.0`;
+    let fileId = `${packageId}/src/lib.mo`;
+    // `_getFileHashes` returns #err until every file of the package is hashed
+    queryResponses.set(packageId, { err: "File hash not found for x" });
+    batchResponses.set(packageId, [[fileId, sha256(bytes("module {}"))]]);
+
+    let download = await verifyDownloadedPackageFiles(
+      packageId,
+      new Map([["src/lib.mo", bytes("module {}")]]),
+    );
+    expect(download).toEqual({ errors: [], unverified: true });
+
+    let { thrown } = await runUpdateLockFile(packageId);
+
+    expect(thrown).toBeUndefined();
+  });
+});

--- a/cli/tests/install-parallel.test.ts
+++ b/cli/tests/install-parallel.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { cli, useTempFixtures } from "./helpers";
+
+// Packages install through a bounded pool instead of one at a time, and
+// transitive deps recurse into that same pool. The set of packages that ends up
+// installed must not depend on how the pool interleaved: a dropped package
+// breaks every downstream build, and a duplicated one wastes a download.
+describe("parallel install", () => {
+  jest.setTimeout(300_000);
+
+  const makeTempFixture = useTempFixtures(
+    path.join(import.meta.dirname, "install-parallel"),
+  );
+
+  const makeTempCacheHome = async () =>
+    await mkdtemp(path.join(os.tmpdir(), "mops-parallel-"));
+
+  const localPackages = (cwd: string): string[] =>
+    readdirSync(path.join(cwd, ".mops"))
+      .filter((entry) => !entry.startsWith("."))
+      .sort();
+
+  const readLock = (cwd: string) =>
+    JSON.parse(readFileSync(path.join(cwd, "mops.lock"), "utf8"));
+
+  test("installs every package in the graph, transitive levels included", async () => {
+    const cwd = await makeTempFixture("graph");
+    const cacheHome = await makeTempCacheHome();
+    const env = { CI: undefined, XDG_CACHE_HOME: cacheHome };
+    const packagesDir = path.join(cacheHome, "mops", "packages");
+
+    try {
+      const result = await cli(["install"], { cwd, env });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/Packages installed/);
+
+      // both root registry deps, the alias that shares core's package id, and
+      // both local levels — `base` is only reachable through lib -> nested
+      expect(readLock(cwd).deps).toEqual({
+        core: "1.0.0",
+        "core@1": "1.0.0",
+        base: "0.16.0",
+        lib: "./lib",
+        nested: "./lib/nested",
+      });
+
+      // nothing the lock records may be missing from `.mops`
+      for (const [name, version] of Object.entries(
+        readLock(cwd).deps as Record<string, string>,
+      )) {
+        if (version.startsWith(".")) {
+          continue;
+        }
+        const dir = path.join(cwd, ".mops", `${name.split("@")[0]}@${version}`);
+        expect(existsSync(path.join(dir, "mops.toml"))).toBe(true);
+      }
+
+      expect(localPackages(cwd)).toEqual(["base@0.16.0", "core@1.0.0"]);
+      expect(
+        existsSync(path.join(packagesDir, "core@1.0.0", "mops.toml")),
+      ).toBe(true);
+      expect(
+        existsSync(path.join(packagesDir, "base@0.16.0", "mops.toml")),
+      ).toBe(true);
+    } finally {
+      rmSync(cacheHome, { recursive: true, force: true });
+    }
+  });
+
+  test("two cold installs of the same graph agree byte for byte", async () => {
+    const first = await makeTempFixture("graph");
+    const second = await makeTempFixture("graph");
+    const cacheA = await makeTempCacheHome();
+    const cacheB = await makeTempCacheHome();
+
+    try {
+      const a = await cli(["install"], {
+        cwd: first,
+        env: { CI: undefined, XDG_CACHE_HOME: cacheA },
+      });
+      const b = await cli(["install"], {
+        cwd: second,
+        env: { CI: undefined, XDG_CACHE_HOME: cacheB },
+      });
+      expect(a.exitCode).toBe(0);
+      expect(b.exitCode).toBe(0);
+
+      // resolution order must not leak from the install pool into the lock
+      expect(readFileSync(path.join(second, "mops.lock"), "utf8")).toBe(
+        readFileSync(path.join(first, "mops.lock"), "utf8"),
+      );
+      expect(localPackages(second)).toEqual(localPackages(first));
+    } finally {
+      rmSync(cacheA, { recursive: true, force: true });
+      rmSync(cacheB, { recursive: true, force: true });
+    }
+  });
+
+  test("a warm install changes nothing", async () => {
+    const cwd = await makeTempFixture("graph");
+    const cacheHome = await makeTempCacheHome();
+    const env = { CI: undefined, XDG_CACHE_HOME: cacheHome };
+
+    try {
+      expect((await cli(["install"], { cwd, env })).exitCode).toBe(0);
+      const lock = readFileSync(path.join(cwd, "mops.lock"), "utf8");
+      const packages = localPackages(cwd);
+
+      const warm = await cli(["install"], { cwd, env });
+      expect(warm.exitCode).toBe(0);
+      expect(readFileSync(path.join(cwd, "mops.lock"), "utf8")).toBe(lock);
+      expect(localPackages(cwd)).toEqual(packages);
+    } finally {
+      rmSync(cacheHome, { recursive: true, force: true });
+    }
+  });
+
+  test("one failing package fails the command without an unhandled rejection", async () => {
+    const cwd = await makeTempFixture("missing-dep");
+    const cacheHome = await makeTempCacheHome();
+    const env = { CI: undefined, XDG_CACHE_HOME: cacheHome };
+
+    try {
+      const result = await cli(["install"], { cwd, env });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr + result.stdout).toMatch(/nonexistent/);
+      expect(result.stderr).not.toMatch(/UnhandledPromiseRejection/);
+      expect(result.stderr).not.toMatch(/ERR_UNHANDLED_REJECTION/);
+
+      // siblings that were in flight alongside the failure still committed
+      // whole packages to the global cache
+      const packagesDir = path.join(cacheHome, "mops", "packages");
+      expect(
+        existsSync(path.join(packagesDir, "core@1.0.0", "mops.toml")),
+      ).toBe(true);
+      expect(
+        readdirSync(packagesDir).filter((entry) =>
+          entry.startsWith(".staging"),
+        ),
+      ).toEqual([]);
+    } finally {
+      rmSync(cacheHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/tests/install-parallel/graph/lib/mops.toml
+++ b/cli/tests/install-parallel/graph/lib/mops.toml
@@ -1,0 +1,6 @@
+[package]
+name = "lib"
+version = "0.1.0"
+
+[dependencies]
+nested = "./nested"

--- a/cli/tests/install-parallel/graph/lib/nested/mops.toml
+++ b/cli/tests/install-parallel/graph/lib/nested/mops.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nested"
+version = "0.1.0"
+
+[dependencies]
+base = "0.16.0"

--- a/cli/tests/install-parallel/graph/mops.toml
+++ b/cli/tests/install-parallel/graph/mops.toml
@@ -1,0 +1,5 @@
+[dependencies]
+core = "1.0.0"
+"core@1" = "1.0.0"
+base = "0.16.0"
+lib = "./lib"

--- a/cli/tests/install-parallel/missing-dep/mops.toml
+++ b/cli/tests/install-parallel/missing-dep/mops.toml
@@ -1,0 +1,4 @@
+[dependencies]
+core = "1.0.0"
+base = "0.16.0"
+nonexistent = "9.9.9"

--- a/cli/tests/local-dep-manifest-lock.test.ts
+++ b/cli/tests/local-dep-manifest-lock.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { cli } from "./helpers";
+
+// These projects declare local `path` dependencies only, so nothing here talks
+// to the registry.
+describe("local path dependency manifests keep mops.lock honest", () => {
+  jest.setTimeout(120_000);
+
+  const scratchDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of scratchDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    scratchDirs.length = 0;
+  });
+
+  // Built at runtime rather than committed: every case here mutates a manifest,
+  // and half of them are only interesting in a second MOPS_ENV.
+  const makeProject = (files: Record<string, string>): string => {
+    const root = mkdtempSync(
+      path.join(import.meta.dirname, "install", "_tmp_local-dep-manifest_"),
+    );
+    scratchDirs.push(root);
+    for (const [file, content] of Object.entries(files)) {
+      const target = path.join(root, file);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, content);
+    }
+    return root;
+  };
+
+  const pkg = (name: string, deps = "") =>
+    `[package]\nname = "${name}"\nversion = "1.0.0"\n${deps && `\n[dependencies]\n${deps}`}`;
+
+  const readLock = (cwd: string) =>
+    JSON.parse(readFileSync(path.join(cwd, "mops.lock"), "utf8"));
+
+  const install = async (cwd: string, env: Record<string, string> = {}) => {
+    const result = await cli(["install"], {
+      cwd,
+      env: { CI: undefined, ...env },
+    });
+    expect(result.stderr).not.toMatch(/RangeError|Maximum call stack/);
+    return result;
+  };
+
+  test("a path dependency that gains a dependency of its own is installed", async () => {
+    const cwd = makeProject({
+      "mops.toml": '[dependencies]\nlib = "./lib"\n',
+      "lib/mops.toml": pkg("lib"),
+      "lib/src/lib.mo": "module {}\n",
+      "nested/mops.toml": pkg("nested"),
+      "nested/src/lib.mo": "module {}\n",
+    });
+
+    expect((await install(cwd)).exitCode).toBe(0);
+    expect(readLock(cwd).deps).toEqual({ lib: "./lib" });
+
+    writeFileSync(
+      path.join(cwd, "lib/mops.toml"),
+      pkg("lib", 'nested = "../nested"\n'),
+    );
+
+    expect((await install(cwd)).exitCode).toBe(0);
+    expect(readLock(cwd).deps).toEqual({ lib: "./lib", nested: "./nested" });
+
+    const sources = await cli(["sources", "--no-install"], {
+      cwd,
+      env: { CI: undefined },
+    });
+    expect(sources.exitCode).toBe(0);
+    expect(sources.stdout).toMatch(/--package nested nested\/src/);
+  });
+
+  test("--locked rejects a lock written before a path dependency's manifest changed", async () => {
+    const cwd = makeProject({
+      "mops.toml": '[dependencies]\nlib = "./lib"\n',
+      "lib/mops.toml": pkg("lib"),
+      "lib/src/lib.mo": "module {}\n",
+      "nested/mops.toml": pkg("nested"),
+      "nested/src/lib.mo": "module {}\n",
+    });
+
+    expect((await install(cwd)).exitCode).toBe(0);
+    const before = readFileSync(path.join(cwd, "mops.lock"), "utf8");
+
+    writeFileSync(
+      path.join(cwd, "lib/mops.toml"),
+      pkg("lib", 'nested = "../nested"\n'),
+    );
+
+    const result = await cli(["install", "--locked"], {
+      cwd,
+      env: { CI: undefined },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(
+      /mops\.lock does not match the local `path` dependencies/,
+    );
+    expect(readFileSync(path.join(cwd, "mops.lock"), "utf8")).toBe(before);
+  });
+
+  // A directory with no manifest must hash differently from one with an empty
+  // manifest, or adding the file would leave the lock looking fresh.
+  test("creating a manifest for a path dependency that had none invalidates the lock", async () => {
+    const cwd = makeProject({
+      "mops.toml": '[dependencies]\nlib = "./lib"\n',
+      "lib/src/lib.mo": "module {}\n",
+      "nested/mops.toml": pkg("nested"),
+      "nested/src/lib.mo": "module {}\n",
+    });
+
+    expect((await install(cwd)).exitCode).toBe(0);
+    expect(readLock(cwd).deps).toEqual({ lib: "./lib" });
+
+    writeFileSync(
+      path.join(cwd, "lib/mops.toml"),
+      pkg("lib", 'nested = "../nested"\n'),
+    );
+
+    expect((await install(cwd)).exitCode).toBe(0);
+    expect(readLock(cwd).deps.nested).toBe("./nested");
+  });
+
+  // Path deps chain and can point back at each other. The freshness walk must
+  // terminate on its own — it runs before anything else can reject the project.
+  test("a cycle between path dependency manifests does not blow the stack", async () => {
+    const cwd = makeProject({
+      "mops.toml": '[dependencies]\na = "./a"\n',
+      "a/mops.toml": pkg("a", 'b = "../b"\n'),
+      "a/src/lib.mo": "module {}\n",
+      "b/mops.toml": pkg("b"),
+      "b/src/lib.mo": "module {}\n",
+    });
+
+    expect((await install(cwd)).exitCode).toBe(0);
+
+    writeFileSync(path.join(cwd, "b/mops.toml"), pkg("b", 'a = "../a"\n'));
+
+    const result = await cli(["install", "--locked"], {
+      cwd,
+      env: { CI: undefined },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(
+      /mops\.lock does not match the local `path` dependencies/,
+    );
+    expect(result.stderr).not.toMatch(/RangeError|Maximum call stack/);
+  });
+
+  // The freshness signal is only recorded for projects that declare a path
+  // dependency, so locks written by a CLI that predates it stay valid.
+  test("a project without path dependencies records no localDepsHash", async () => {
+    const cwd = makeProject({ "mops.toml": "[dependencies]\n" });
+
+    expect((await install(cwd)).exitCode).toBe(0);
+    expect(readLock(cwd)).not.toHaveProperty("localDepsHash");
+
+    const locked = await cli(["install", "--locked"], {
+      cwd,
+      env: { CI: undefined },
+    });
+    expect(locked.exitCode).toBe(0);
+  });
+});
+
+describe("{MOPS_ENV} path dependencies re-resolve per environment", () => {
+  jest.setTimeout(120_000);
+
+  const scratchDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of scratchDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    scratchDirs.length = 0;
+  });
+
+  const makeEnvProject = (): string => {
+    const root = mkdtempSync(
+      path.join(import.meta.dirname, "install", "_tmp_mops-env-dep_"),
+    );
+    scratchDirs.push(root);
+    writeFileSync(
+      path.join(root, "mops.toml"),
+      '[dependencies]\nenvdep = "./envs/{MOPS_ENV}/dep"\n',
+    );
+    for (const env of ["local", "staging"]) {
+      const dir = path.join(root, "envs", env, "dep");
+      mkdirSync(path.join(dir, "src"), { recursive: true });
+      writeFileSync(
+        path.join(dir, "mops.toml"),
+        '[package]\nname = "envdep"\nversion = "1.0.0"\n',
+      );
+      writeFileSync(path.join(dir, "src/lib.mo"), "module {}\n");
+    }
+    return root;
+  };
+
+  const readLock = (cwd: string) =>
+    JSON.parse(readFileSync(path.join(cwd, "mops.lock"), "utf8"));
+
+  test("install under a new MOPS_ENV re-resolves instead of keeping the old paths", async () => {
+    const cwd = makeEnvProject();
+
+    const first = await cli(["install"], {
+      cwd,
+      env: { CI: undefined, MOPS_ENV: "local" },
+    });
+    expect(first.exitCode).toBe(0);
+    expect(readLock(cwd).deps.envdep).toBe("./envs/local/dep");
+
+    const second = await cli(["install"], {
+      cwd,
+      env: { CI: undefined, MOPS_ENV: "staging" },
+    });
+    expect(second.exitCode).toBe(0);
+    expect(readLock(cwd).deps.envdep).toBe("./envs/staging/dep");
+
+    const sources = await cli(["sources", "--no-install"], {
+      cwd,
+      env: { CI: undefined, MOPS_ENV: "staging" },
+    });
+    expect(sources.stdout).toMatch(/--package envdep envs\/staging\/dep\/src/);
+  });
+
+  test("--locked rejects a lock generated under a different MOPS_ENV", async () => {
+    const cwd = makeEnvProject();
+
+    expect(
+      (
+        await cli(["install"], {
+          cwd,
+          env: { CI: undefined, MOPS_ENV: "local" },
+        })
+      ).exitCode,
+    ).toBe(0);
+
+    const result = await cli(["install", "--locked"], {
+      cwd,
+      env: { CI: undefined, MOPS_ENV: "staging" },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/MOPS_ENV differs/);
+
+    const same = await cli(["install", "--locked"], {
+      cwd,
+      env: { CI: undefined, MOPS_ENV: "local" },
+    });
+    expect(same.exitCode).toBe(0);
+  });
+
+  // `mops sources` never writes the lock, so a stale one must not be allowed to
+  // feed the previous environment's paths to moc.
+  test("sources under a new MOPS_ENV does not serve the locked environment's paths", async () => {
+    const cwd = makeEnvProject();
+
+    expect(
+      (
+        await cli(["install"], {
+          cwd,
+          env: { CI: undefined, MOPS_ENV: "local" },
+        })
+      ).exitCode,
+    ).toBe(0);
+
+    const sources = await cli(["sources", "--no-install"], {
+      cwd,
+      env: { CI: undefined, MOPS_ENV: "staging" },
+    });
+    expect(sources.exitCode).toBe(0);
+    expect(sources.stdout).toMatch(/--package envdep envs\/staging\/dep\/src/);
+    expect(sources.stdout).not.toMatch(/envs\/local\/dep/);
+  });
+});

--- a/cli/tests/locked.test.ts
+++ b/cli/tests/locked.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, jest, test } from "@jest/globals";
 import {
   existsSync,
+  mkdtempSync,
   readFileSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "path";
 import { cli } from "./helpers";
 
@@ -181,7 +183,9 @@ describe("--locked", () => {
   // Replaces the old #514 regression test. A corrupted hash *value* still
   // satisfies every staleness check, so plain `mops install` does not rewrite
   // it — which means the error must not tell the operator to run `mops install`,
-  // or CI loops forever on advice that cannot work.
+  // or CI loops forever on advice that cannot work. Note this is the
+  // already-installed case; when install has to download the package it does
+  // check the bytes against the lock (see the download-time test below).
   test("fails on a locked file hash that disagrees with the registry, with a hint that recovers", async () => {
     cleanup();
     try {
@@ -292,9 +296,10 @@ describe("--locked", () => {
     }
   });
 
-  // Verification moved to download time, so install no longer re-hashes
-  // `.mops/`. This is the guarantee change in this release: install is not a
-  // tamper gate any more — `mops verify` is.
+  // Verification moved to download time: install checks the bytes it downloads
+  // and re-hashes nothing already on disk. So install is still a tamper gate,
+  // but only for what it fetches — a locally edited `.mops/` file survives it,
+  // and `mops verify` is what catches that.
   test("tolerates a locally edited .mops/ file that mops verify rejects", async () => {
     cleanup();
     try {
@@ -320,6 +325,35 @@ describe("--locked", () => {
         /Delete the `\.mops\/core@1\.0\.0` directory and run `mops install`/,
       );
     } finally {
+      cleanup();
+    }
+  });
+
+  // The other half of that guarantee: plain install, with no --locked, refuses
+  // bytes that disagree with the lock. `XDG_CACHE_HOME` gives the run an empty
+  // global cache so the package is actually downloaded.
+  test("plain install refuses a download that disagrees with mops.lock", async () => {
+    cleanup();
+    const cache = mkdtempSync(path.join(tmpdir(), "mops-cache-"));
+    try {
+      await install();
+      const lock = readLock();
+      const fileId = Object.keys(lock.hashes["core@1.0.0"])[0] as string;
+      lock.hashes["core@1.0.0"][fileId] = "b".repeat(64);
+      writeLock(lock);
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+
+      const result = await cli(["install"], {
+        cwd,
+        env: { CI: undefined, XDG_CACHE_HOME: cache },
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(
+        /mops\.lock and the registry disagree about the published file hashes/,
+      );
+      expect(existsSync(path.join(cwd, ".mops", "core@1.0.0"))).toBe(false);
+    } finally {
+      rmSync(cache, { recursive: true, force: true });
       cleanup();
     }
   });

--- a/cli/tests/remove-dry-run.test.ts
+++ b/cli/tests/remove-dry-run.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { cli, useTempFixtures } from "./helpers";
+
+// `--dry-run` used to delete the local cache entries, print "Package removed",
+// and rewrite an already-stale mops.lock through checkIntegrity.
+describe("remove --dry-run", () => {
+  jest.setTimeout(120_000);
+
+  const makeTempFixture = useTempFixtures(
+    path.join(import.meta.dirname, "remove-dry-run"),
+  );
+
+  // deliberately disagrees with mops.toml, so any lock maintenance rewrites it
+  const staleLock = JSON.stringify({
+    version: 3,
+    deps: { core: "0.9.0" },
+    graph: {},
+  });
+
+  test("changes nothing on disk and says so", async () => {
+    const cwd = await makeTempFixture("basic");
+    const toml = path.join(cwd, "mops.toml");
+    const lock = path.join(cwd, "mops.lock");
+    const localCache = path.join(cwd, ".mops", "core@1.0.0");
+
+    writeFileSync(lock, staleLock);
+    mkdirSync(localCache, { recursive: true });
+    writeFileSync(path.join(localCache, "mops.toml"), "[package]\n");
+
+    const tomlBefore = readFileSync(toml, "utf8");
+
+    const res = await cli(["remove", "core", "--dry-run", "--verbose"], {
+      cwd,
+      env: { CI: "1" },
+    });
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toMatch(/Would remove package core = "1\.0\.0"/);
+    expect(res.stdout).toMatch(/Would remove local cache .*core@1\.0\.0/);
+    expect(res.stdout).not.toMatch(/Package removed/);
+
+    expect(readFileSync(toml, "utf8")).toBe(tomlBefore);
+    expect(readFileSync(lock, "utf8")).toBe(staleLock);
+    expect(existsSync(path.join(localCache, "mops.toml"))).toBe(true);
+  });
+
+  test("reports an unknown package without touching the lock", async () => {
+    const cwd = await makeTempFixture("basic");
+    const lock = path.join(cwd, "mops.lock");
+    writeFileSync(lock, staleLock);
+
+    const res = await cli(["remove", "nope", "--dry-run"], {
+      cwd,
+      env: { CI: "1" },
+    });
+
+    expect(res.stdout).toMatch(/No dependency to remove "nope"/);
+    expect(readFileSync(lock, "utf8")).toBe(staleLock);
+  });
+});

--- a/cli/tests/remove-dry-run/basic/mops.toml
+++ b/cli/tests/remove-dry-run/basic/mops.toml
@@ -1,0 +1,2 @@
+[dependencies]
+core = "1.0.0"

--- a/cli/tests/startup-latency.test.ts
+++ b/cli/tests/startup-latency.test.ts
@@ -1,0 +1,98 @@
+import http from "node:http";
+import { AddressInfo } from "node:net";
+import path, { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execa } from "execa";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
+
+// The registry canister id is irrelevant to the stub, which answers every path,
+// but it must be a valid principal for the agent to encode the request.
+const CANISTER_ID = "oknww-riaaa-aaaam-qaf6a-cai";
+const PROBE = path.join(
+  dirname(fileURLToPath(import.meta.url)),
+  "startup-latency/probe.ts",
+);
+
+interface Request {
+  method: string;
+  path: string;
+  bodyLength: number;
+}
+
+let server: http.Server;
+let requests: Request[] = [];
+let host = "";
+
+// notifyInstalls pulls in the generated candid declarations, which jest's ESM
+// resolver cannot load in-process, so the probe runs in a real node process.
+const runProbe = async (deps: Record<string, string>) => {
+  const result = await execa("npx", ["tsx", PROBE, JSON.stringify(deps)], {
+    env: {
+      ...process.env,
+      MOPS_NETWORK: "ic",
+      MOPS_REGISTRY_HOST: host,
+      MOPS_REGISTRY_CANISTER_ID: CANISTER_ID,
+    },
+    stdio: "pipe",
+    reject: false,
+  });
+  expect(result.exitCode).toBe(0);
+  return JSON.parse(result.stdout) as { ms: number };
+};
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    let length = 0;
+    req.on("data", (chunk: Buffer) => (length += chunk.length));
+    req.on("end", () => {
+      requests.push({
+        method: req.method ?? "",
+        path: req.url ?? "",
+        bodyLength: length,
+      });
+      res.writeHead(202).end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  host = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  requests = [];
+});
+
+describe("notifyInstalls", () => {
+  test("submits one v2 call and never waits for a certified reply", async () => {
+    await runProbe({ core: "2.1.0", base: "0.14.0" });
+
+    expect(requests.map((r) => `${r.method} ${r.path}`)).toEqual([
+      `POST /api/v2/canister/${CANISTER_ID}/call`,
+    ]);
+    expect(requests[0]!.bodyLength).toBeGreaterThan(0);
+  });
+
+  test("does not sync time against the ICP ledger canister", async () => {
+    await runProbe({ core: "2.1.0" });
+
+    // An eager syncTime reads state from ryjl3-tyaaa-aaaaa-aaaba-cai.
+    expect(requests.some((r) => r.path.includes("read_state"))).toBe(false);
+    expect(requests.some((r) => r.path.includes("ryjl3-tyaaa"))).toBe(false);
+  });
+
+  test("skips the call entirely when no mops packages were installed", async () => {
+    await runProbe({ local: "./vendor/local", gh: "https://github.com/o/r" });
+
+    expect(requests).toEqual([]);
+  });
+});

--- a/cli/tests/startup-latency/probe.ts
+++ b/cli/tests/startup-latency/probe.ts
@@ -1,0 +1,8 @@
+// Spawned by ../startup-latency.test.ts. Runs notifyInstalls in a real process
+// against a stub replica, so the test can assert both what goes on the wire and
+// that nothing left behind keeps the process alive.
+import { notifyInstalls } from "../../notify-installs.js";
+
+let start = Date.now();
+await notifyInstalls(JSON.parse(process.argv[2] ?? "{}"));
+console.log(JSON.stringify({ ms: Date.now() - start }));

--- a/cli/tests/sync-plan.test.ts
+++ b/cli/tests/sync-plan.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// `api/actors` pulls in the generated `*.did.js` declarations, which the ESM
+// `.js` -> extensionless moduleNameMapper resolves to the raw `.did` files.
+// Only the pure planning helpers are under test here.
+jest.unstable_mockModule("../api/actors.js", () => ({
+  mainActor: jest.fn(),
+  mainOnewayCall: jest.fn(),
+  storageActor: jest.fn(),
+}));
+
+const { computeSyncPlan, getSourceFiles, parseImportedPackage } =
+  await import("../commands/sync.js");
+
+type SyncPlan = {
+  add: { name: string; dev: boolean }[];
+  remove: { name: string; dev: boolean }[];
+};
+
+const used = (prod: string[] = [], dev: string[] = []) => ({
+  prod: new Set(prod),
+  dev: new Set(dev),
+});
+
+const declared = (deps: string[] = [], devDeps: string[] = []) => ({
+  deps: new Set(deps),
+  devDeps: new Set(devDeps),
+});
+
+const plan = (p: SyncPlan) => ({
+  add: p.add.map((e) => `${e.name}${e.dev ? " (dev)" : ""}`),
+  remove: p.remove.map((e) => `${e.name}${e.dev ? " (dev)" : ""}`),
+});
+
+describe("parseImportedPackage", () => {
+  test("keeps the pinned alias", () => {
+    expect(parseImportedPackage("mo:map@8.1.0/Map")).toBe("map@8.1.0");
+    expect(parseImportedPackage("mo:map@8.1.0")).toBe("map@8.1.0");
+  });
+
+  test("returns the package name of a plain import", () => {
+    expect(parseImportedPackage("mo:core/Array")).toBe("core");
+    expect(parseImportedPackage("mo:core")).toBe("core");
+    expect(parseImportedPackage("mo:core/Array\r")).toBe("core");
+  });
+
+  test("skips non-package deps", () => {
+    expect(parseImportedPackage("mo:prim")).toBeUndefined();
+    expect(parseImportedPackage("mo:⛔")).toBeUndefined();
+    expect(parseImportedPackage("canister:foo")).toBeUndefined();
+    expect(parseImportedPackage("/abs/path/Lib.mo")).toBeUndefined();
+  });
+});
+
+// A pinned alias (`"map@8.1.0" = "8.1.0"`) is imported as `mo:map@8.1.0`, so
+// the used set and the declared keys live in the same namespace. Reducing
+// either side to the base name made sync add-then-remove the `map` key.
+describe("computeSyncPlan pinned aliases", () => {
+  test("alias declared and used is left alone", () => {
+    expect(
+      plan(computeSyncPlan(used(["map@8.1.0"]), declared(["map@8.1.0"]))),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  test("alias declared but unused is removed, and only the alias key", () => {
+    expect(plan(computeSyncPlan(used([]), declared(["map@8.1.0"])))).toEqual({
+      add: [],
+      remove: ["map@8.1.0"],
+    });
+  });
+
+  test("base name and alias both declared and both used", () => {
+    expect(
+      plan(
+        computeSyncPlan(
+          used(["map", "map@8.1.0"]),
+          declared(["map", "map@8.1.0"]),
+        ),
+      ),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  test("using the base name does not keep an unused alias alive", () => {
+    expect(
+      plan(computeSyncPlan(used(["map"]), declared(["map", "map@8.1.0"]))),
+    ).toEqual({ add: [], remove: ["map@8.1.0"] });
+  });
+
+  test("an undeclared alias import is added under its alias key", () => {
+    expect(
+      plan(computeSyncPlan(used(["map", "map@8.1.0"]), declared(["map"]))),
+    ).toEqual({ add: ["map@8.1.0"], remove: [] });
+  });
+
+  test("a plain package with no alias round-trips", () => {
+    expect(plan(computeSyncPlan(used(["core"]), declared(["core"])))).toEqual({
+      add: [],
+      remove: [],
+    });
+  });
+});
+
+describe("getSourceFiles", () => {
+  const makeProject = (files: string[]) => {
+    let root = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "mops-sync-sources-")),
+    );
+    for (let file of files) {
+      fs.mkdirSync(path.join(root, path.dirname(file)), { recursive: true });
+      fs.writeFileSync(path.join(root, file), "");
+    }
+    return root;
+  };
+
+  test("classifies test and bench sources as dev", () => {
+    let root = makeProject([
+      "src/Main.mo",
+      "test/main.test.mo",
+      "test/utils.mo",
+      "tests/nested/other.test.mo",
+      "bench/main.bench.mo",
+      "benchmark/other.bench.mo",
+      "src/latest/Contest.mo",
+      "node_modules/pkg/Ignored.mo",
+      ".mops/dep/Ignored.mo",
+    ]);
+    let files = getSourceFiles(root);
+    expect(files.prod.sort()).toEqual(["src/Main.mo", "src/latest/Contest.mo"]);
+    expect(files.dev.sort()).toEqual([
+      "bench/main.bench.mo",
+      "benchmark/other.bench.mo",
+      "test/main.test.mo",
+      "test/utils.mo",
+      "tests/nested/other.test.mo",
+    ]);
+  });
+});
+
+describe("computeSyncPlan dev classification", () => {
+  test("a package used only from test/bench sources becomes a dev dependency", () => {
+    expect(plan(computeSyncPlan(used([], ["test"]), declared()))).toEqual({
+      add: ["test (dev)"],
+      remove: [],
+    });
+  });
+
+  test("a package used in both goes to dependencies", () => {
+    expect(plan(computeSyncPlan(used(["core"], ["core"]), declared()))).toEqual(
+      {
+        add: ["core"],
+        remove: [],
+      },
+    );
+  });
+
+  test("dev usage keeps a production dependency declared", () => {
+    expect(
+      plan(computeSyncPlan(used([], ["core"]), declared(["core"]))),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  test("production usage keeps a dev dependency declared", () => {
+    expect(
+      plan(computeSyncPlan(used(["core"]), declared([], ["core"]))),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  test("an unused package declared in both sections is removed from both", () => {
+    expect(
+      plan(computeSyncPlan(used([]), declared(["core"], ["core"]))),
+    ).toEqual({ add: [], remove: ["core", "core (dev)"] });
+  });
+
+  test("an unused dev dependency is removed as dev", () => {
+    expect(plan(computeSyncPlan(used([]), declared([], ["test"])))).toEqual({
+      add: [],
+      remove: ["test (dev)"],
+    });
+  });
+});

--- a/docs/docs/10-mops.lock.md
+++ b/docs/docs/10-mops.lock.md
@@ -43,6 +43,7 @@ mops.lock
 - pinning a dependency to a different version than `mops.toml` declares
 - recording file hashes for packages that are not in its own `deps`
 - carrying absolute local `path` dependencies written by an older CLI
+- generated before a local `path` dependency's own `mops.toml` changed, or under a different `MOPS_ENV`
 
 A broken lockfile is only a dead end under [`--locked`](#ci-environments), where failing is the point.
 
@@ -57,7 +58,7 @@ Pass `--locked` and commit `mops.lock`:
 - run: mops test --locked
 ```
 
-`--locked` requires an up-to-date lockfile and never writes it. It fails when the lockfile is missing, unparseable, not the current format, does not pin the dependencies declared in `mops.toml`, or records a file hash that disagrees with the Mops registry.
+`--locked` requires an up-to-date lockfile and never writes it. It fails when the lockfile is missing, unparseable, not the current format, does not pin the dependencies declared in `mops.toml`, was generated before a local `path` dependency's `mops.toml` changed, or records a file hash that disagrees with the Mops registry.
 
 `--locked` is available on `mops install` and on every command that installs dependencies implicitly (`mops build`, `mops check`, `mops check-candid`, `mops check-stable`, `mops test`, `mops bench`, `mops generate candid`), so a job can run `mops test --locked` with no preceding install step.
 
@@ -69,11 +70,13 @@ The `CI` environment variable does not affect lockfile behavior. Releases before
 
 ### What `--locked` does not check
 
-`--locked` does not re-walk the dependency graph from scratch. Installing from a lockfile deliberately skips the dependency versions that lost a version conflict, so their manifests are never downloaded and a full re-resolve is not possible without giving up that optimization. In practice this is not a gap for registry dependencies: published versions are immutable, so a transitive version cannot change underneath a lockfile. It does mean that transitive changes reached through a local `path` dependency are not detected by `--locked`.
+`--locked` does not re-walk the dependency graph from scratch. Installing from a lockfile deliberately skips the dependency versions that lost a version conflict, so their manifests are never downloaded and a full re-resolve is not possible without giving up that optimization. In practice this is not a gap for registry dependencies: published versions are immutable, so a transitive version cannot change underneath a lockfile.
+
+Local `path` dependencies are live directories, so Mops instead records a hash of the `[dependencies]` of every path dependency it reaches, transitively. Editing one of those manifests — or creating a `mops.toml` where there was none — makes the lockfile stale, so a plain `mops install` picks up the new transitive dependency and `--locked` fails instead of building against a dependency set that no longer matches. What is still not checked is the *file contents* of a local path dependency: it is a directory you edit by design and carries no published hashes.
 
 ## Integrity
 
-File integrity is verified **at download time**: each file is hashed as it arrives and compared against the hash published in the Mops registry, and the package is only committed to the cache if every file matches. A corrupted or tampered download therefore never reaches your project.
+File integrity is verified **at download time**: each file is hashed as it arrives and compared against the hash published in the Mops registry, and the package is only committed to the cache if every file matches. Where `mops.lock` already records hashes for the package, the registry's answer is checked against the lockfile first, and a disagreement is reported rather than trusted. A corrupted or tampered download therefore never reaches your project — this holds for a plain `mops install`, not only under `--locked`.
 
 `mops install` does not re-hash the contents of `.mops/` on every run. Editing a file under `.mops/` will not fail your next install — run [`mops verify`](./cli/1-deps/06-mops-verify.md) for the full on-disk audit.
 
@@ -86,6 +89,7 @@ _It's only faster when there are no globally cached packages — for example whe
 ## What `mops.lock` contains
 
 - Hash of the `[dependencies]` and `[dev-dependencies]` sections of `mops.toml`
+- Hash of the `[dependencies]` of every local `path` dependency, transitively (`localDepsHash`, omitted when the project declares none)
 - All transitive dependencies with the final resolved versions
 - Hash of each file of each registry dependency (retrieved from the Mops registry canister)
 - The declared dependencies of every registry package version in the graph (`graph`), including versions that lost a conflict and were not installed
@@ -95,3 +99,16 @@ The `graph` section lets Mops update the lock after `mops add`, `remove`, `updat
 For the same reason, updating a stale lock carries file hashes of already-locked packages over and queries the registry only for packages new to the lock. Deleting `mops.lock` and running `mops install` rebuilds every hash from the registry.
 
 Local path dependencies are stored relative to the project root (e.g. `./packages/shared`, `../lib`) so the lockfile is portable across machines. A lockfile that still carries absolute paths from an older CLI is treated as stale and rewritten by a plain `mops install`. After regenerating, use a CLI that includes this fix; older CLIs treat relative lock paths as cwd-relative and break when run from a subdirectory.
+
+## `{MOPS_ENV}` path dependencies
+
+A local `path` dependency may contain `{MOPS_ENV}`, which expands to the value of the `MOPS_ENV` environment variable (`local` when it is unset):
+
+```toml
+[dependencies]
+envdep = "./envs/{MOPS_ENV}/dep"
+```
+
+The lockfile stores the **expanded** path, which makes it specific to the `MOPS_ENV` it was generated under. Mops therefore treats a lockfile generated under a different `MOPS_ENV` as stale: `mops install` re-resolves and rewrites it, `mops sources` reports the current environment's directories, and `mops install --locked` fails rather than building against the previous environment's paths.
+
+The consequence for CI is that a committed lockfile only satisfies `--locked` for the `MOPS_ENV` it was generated under. If you build the same project under several environments, either run `mops install` (without `--locked`) in those jobs, or commit one lockfile per environment branch. Projects that do not use `{MOPS_ENV}` are unaffected.

--- a/docs/docs/cli/1-deps/05-mops-sync.md
+++ b/docs/docs/cli/1-deps/05-mops-sync.md
@@ -13,4 +13,32 @@ Analyze source code and:
 mops sync
 ```
 
-The [lockfile](../../10-mops.lock.md) is always kept in sync — there is no flag to opt out.
+`mops sync` compiles nothing, but it does read your imports with `moc`, so it requires a pinned [`[toolchain] moc`](../../06-toolchain-management.md).
+
+### `--dry-run`
+
+Print what would be added and removed without touching `mops.toml`, the local cache or the [lockfile](../../10-mops.lock.md).
+
+```
+mops sync --dry-run
+```
+
+```
+Would add core
+Would remove itertools
+Would add fuzz (dev)
+```
+
+## Dev dependencies
+
+A package imported only from `test`, `tests`, `bench` or `benchmark` directories is added to `[dev-dependencies]`. A package imported anywhere else is added to `[dependencies]`, even if it is also used in tests.
+
+Packages that are already declared are never moved between the two sections — `mops sync` only classifies packages it adds.
+
+## Pinned aliases
+
+[Pinned aliases](../../articles/00-dependency-version-pinning.md) are matched against imports verbatim, so `mo:map@8.1.0` corresponds to the `"map@8.1.0"` key and `mo:map` to the `map` key. The two are tracked independently: removing one never rewrites the other.
+
+## Lockfile
+
+The [lockfile](../../10-mops.lock.md) is always kept in sync — there is no flag to opt out, except `--dry-run`, which writes nothing at all.

--- a/docs/docs/cli/7-misc/03-mops-cache.md
+++ b/docs/docs/cli/7-misc/03-mops-cache.md
@@ -11,7 +11,9 @@ When you run `mops install`, `mops add <pkg>` or `mops toolchain use/update`, Mo
 
 Local cache directory is created in the project root in the `.mops` directory.
 
-Files are verified against the hashes published in the Mops registry as they are downloaded, before they enter the cache. To audit what is already on disk against [mops.lock](../../10-mops.lock.md), run [`mops verify`](../1-deps/06-mops-verify.md).
+Files are verified as they are downloaded, before they enter the cache. When [mops.lock](../../10-mops.lock.md) already records the package, its hashes are the reference — a local, committed record, so no registry round trip is needed. Otherwise the hashes published in the Mops registry are used.
+
+Verification happens on download, so a package served from the cache is not re-hashed. To audit what is already on disk, run [`mops verify`](../1-deps/06-mops-verify.md).
 
 ### `mops cache show`
 
@@ -24,3 +26,11 @@ Print global cache size.
 ### `mops cache clean`
 
 Clean global and local cache directories.
+
+Pass `--global` to clean only the global cache and keep the project's `.mops` directory:
+
+```
+mops cache clean --global
+```
+
+Run outside a project (no `mops.toml` in any parent directory), `mops cache clean` only cleans the global cache.


### PR DESCRIPTION
A warm-cache `mops install && mops update` — the shape of a CI or agent session start — drops from ~3.8 s to ~2.3 s wall, or **2.2 s → 0.7 s** of actual work once Node's interpreter startup is excluded. A cold install of 8 root packages plus transitives goes **19.7 s → 13.2 s**, and the consensus round trips that dominated it go from *P+1 serialized* to at most one batched call — zero on a clean clone with a committed lock.

Two of the fixes here are silent wrong builds: `mops install` exiting 0 while leaving a dependency set that does not match the manifests.

## A local `path` dependency's manifest never invalidated the lockfile

`mops.lock`'s freshness hash covered only the root manifest's `[dependencies]`, and `checkLockedDeps` skips `path` deps entirely. So editing a local package's own `mops.toml` changed nothing the lockfile could notice: resolution short-circuited to `lock.deps`, and the new dependency was never fetched or passed to the compiler.

```
# root mops.toml:  lib = "./lib"
# then add  base = "0.16.0"  to lib/mops.toml

$ mops install
Before: (exit 0, nothing installed — .mops/ empty, lock unchanged)
After:  installed base@0.16.0, lock updated

$ mops sources
Before: --package lib lib
After:  --package lib lib
        --package base .mops/base@0.16.0/src
```

`lib` could not compile against `base`, and mops reported success. It evaded detection because nothing was *wrong* — the lock was internally consistent and matched the root manifest exactly; the input that changed was simply not part of the hash.

The lockfile now records a hash of the `[dependencies]` of every path dependency it reaches, transitively, in a new optional `localDepsHash` field. Only `[dependencies]` of nested manifests are hashed, matching what resolution actually walks. A missing manifest hashes distinctly from an empty one, so *creating* one invalidates. The walk carries a visited set — without it a `a → ../b → ../a` cycle produces a `RangeError` inside the hasher.

## `{MOPS_ENV}` left the lockfile pinned to the previous environment

`{MOPS_ENV}` is expanded when the value is written to `mops.lock`, but the freshness check compared the *unexpanded* string, which is identical in every environment.

```
# mops.toml:  envdep = "./envs/{MOPS_ENV}/dep"

$ MOPS_ENV=local mops install
$ MOPS_ENV=staging mops sources
Before: --package envdep envs/local/dep      # wrong environment
After:  --package envdep envs/staging/dep

$ MOPS_ENV=staging mops install
Before: exit 0, lock still ./envs/local/dep  # refuses to re-resolve
After:  re-resolves and rewrites the lock
```

A committed lock silently baked in whichever `MOPS_ENV` last ran install. The placeholder is now expanded into the local-deps signature, so switching environments makes the lock stale.

## Where the latency went

The fixed per-invocation cost was almost entirely avoidable. The install-telemetry call is submitted as an ingress message and acknowledged on acceptance rather than waiting for a certified reply (1111 ms → 125 ms measured); it is `oneway`, so delivery is unchanged. The agent no longer eagerly synchronises time, which cost three `read_state` requests against the *ICP ledger canister* — a canister mops never otherwise talks to, on a different subnet — on every run; clock skew still self-heals lazily against the mops canister. And `mops install` overlaps the API compatibility query with the install rather than serialising on it.

On the cold path, download verification used one consensus update call *per package* (~1.2–2.5 s each), awaited before the package entered the cache and therefore blocking the next package too, since installs were sequential. It now uses the registry's existing query method, and packages install concurrently under a fixed request budget (16 fetches, 8 in CI) shared between the package pool and the per-package file pool so the two cannot multiply. Transitive levels run one package at a time, which bounds in-flight work at any graph depth without a global semaphore — a parent holding a slot while awaiting children would deadlock.

## Integrity: a faster path that was deliberately walked back

Moving verification onto query calls also made query-derived hashes the *contents* of `mops.lock`. Package bytes are already query-served, so the consensus fetch was the only thing standing between a single malicious subnet node and forging both bytes and matching hashes — and the lock would then launder them forward as the project's trust anchor.

So lock contents are now always consensus-derived, and the two sources are compared, with distinct diagnoses because the remedies differ: `mops.lock` disagreeing with the registry means one of the two records is wrong (restore or regenerate the lock), while the registry contradicting *itself* between its query and consensus replies means the cached copy is tainted (`mops cache clean`, and report it). An empty query answer is excluded from comparison — the registry's hash backfill only ever adds, and a lagging query node can only show fewer hashes, so that case is benign and never a false positive.

The net effect is that `mops.lock` becomes a real trust anchor on the install path: when it covers a package, downloads verify against it — a local, committed record — which is why a clean clone with a committed lock needs no consensus call at all. This is cargo's model with `Cargo.lock`.

## Migration

`downloadFile` and `downloadPackageFiles` return `Uint8Array` instead of `Array<number>`. This affects programmatic consumers of the `ic-mops` package only; nothing in the CLI surface changes.

Projects that declare a local `path` dependency have their lockfile regenerated once on the next `mops install`, and `mops install --locked` fails until the regenerated lock is committed — those locks were unverifiable, and some were genuinely wrong. Projects without path dependencies are entirely unaffected: `localDepsHash` is omitted from the JSON, and existing lockfiles stay valid.

A committed lockfile now satisfies `--locked` only for the `MOPS_ENV` it was generated under. Multi-environment pipelines should keep one lock per environment or drop `--locked`.

Plain `mops install` now fails when it has to *download* a package whose hashes disagree with the committed lock. Files already on disk under `.mops/` are still not re-hashed by an install — `mops verify` remains the command that audits those.

## What is unchanged

Three verified resolver defects are deliberately **not** fixed here, because each changes diagnostics or the installed package set across every project at once and deserves its own decision rather than riding along in a latency change: `0.x` minor skew is still never reported (`base 0.7.3` against `0.16.0` silently collapses, and most of the Motoko ecosystem is `0.x`); conflict reporting is still inert once `mops.lock` is fresh, which makes `mops sources --conflicts error` a no-op in CI; and the transitive closure still includes packages declared only by versions that lost the max-wins comparison. Fixing the second and third would also require a snapshot update, and the first would newly fail any pipeline that opted into `--conflicts error`.

Those, plus the store-level work (content-addressable store with hardlinks, cache pruning, `--offline`), the command-surface gaps, and the registry-side changes, are catalogued with repros in [#723](https://github.com/caffeinelabs/mops/issues/723).

## Follow-up worth flagging

`collectDeps` and the local-path install recursion still walk `path` dependencies without a visited set, so a dependency cycle stack-overflows with a raw `RangeError` on a cold install, before any lock exists. The hasher added here is guarded; those two call sites are not. Tracked as item 4 in [#723](https://github.com/caffeinelabs/mops/issues/723).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
