### PR TITLE
fix(cli): sync alias data loss, remove --dry-run side effects, cache clean guard

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -217,7 +217,10 @@ mops update core          # update specific package within caret bound
 mops update --major       # allow updates that cross major versions
 mops update --patch       # restrict to patch bumps only (mutually exclusive with --major)
 mops sync                 # add missing / remove unused packages
+mops sync --dry-run       # print what would change, write nothing
 ```
+
+`mops sync` needs a pinned `[toolchain] moc` — it reads imports with `moc --print-deps`. Packages imported only from `test`/`tests`/`bench`/`benchmark` directories are added to `[dev-dependencies]`; already-declared packages are never moved between sections.
 
 ## Other Commands
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,21 @@
 - `mops remove` now echoes the dependency value it removed for GitHub and local path deps, instead of an empty version.
 - Temporary compatibility shim: `mops add`, `remove`, `install`, `sync` and `update` again accept the removed 2.x flag `--lock <check|update|ignore>` instead of failing to parse. The value is ignored — including `check`, which is **not** treated as `--locked` — so v2 call sites keep working during the 3.x rollout. Migrate to `mops install --locked` for CI enforcement; the flag will be removed.
 
+### Fixed
+
+- **`mops sync` no longer destroys a pinned alias dependency.** Given `map = "9.0.1"` and `"map@8.1.0" = "8.1.0"`, sync compared imports (`map@8.1.0`) against alias-stripped manifest keys (`map`), so it reported the alias as both missing and unused — adding it overwrote `map` with `8.1.0`, and a single run could remove the dependency entirely. Aliases are now matched verbatim and added under their own key.
+- `mops sync` adds packages imported only from `test`, `tests`, `bench` or `benchmark` directories to `[dev-dependencies]` rather than `[dependencies]`. Already-declared packages are never moved between sections.
+- `mops sync` removes an unused package from **both** sections when it is declared in both; previously it was only removed from `[dependencies]`, leaving a dangling entry that the next run reported again.
+- `mops sync` is roughly twice as fast — it runs `moc --print-deps` once per file instead of twice.
+- `mops remove --dry-run` is now side-effect free. It no longer deletes local cache directories or rewrites a stale `mops.lock`, and it prints `Would remove package …` instead of reporting the removal as done.
+- **`mops cache clean` works on Windows and on non-`ic` networks.** Its safety guard compared a `path.join` result against a forward-slash suffix, so it failed with "Invalid cache directory" on every Windows run and for every network-scoped cache directory. The replacement is separator-agnostic and strictly narrower: it also requires the directory to be inside the global cache root, rejecting a traversing `MOPS_NETWORK`.
+- `mops cache clean` no longer deletes `./.mops` when run outside a project, where an empty root directory made it target the current working directory.
+
+### Added
+
+- `mops sync --dry-run` prints what would be added and removed without touching `mops.toml`, the local cache or `mops.lock`.
+- `mops cache clean --global` cleans only the global cache and keeps the project's `.mops` directory.
+
 ## 3.0.0 (unreleased)
 
 ### Migrating from 2.x

--- a/cli/cache.ts
+++ b/cli/cache.ts
@@ -132,26 +132,6 @@ export function getGithubDepCacheName(name: string, repo: string) {
   );
 }
 
-export let addCache = async (cacheName: string, source: string) => {
-  let dest = path.join(getGlobalCacheDir(), "packages", cacheName);
-  let staging = createStagingDir(dest);
-
-  try {
-    await new Promise<void>((resolve, reject) => {
-      ncp.ncp(source, staging, { stopOnErr: true }, (err) => {
-        if (err) {
-          reject(err);
-        }
-        resolve();
-      });
-    });
-    commitStagingDir(staging, dest);
-  } catch (err) {
-    fs.rmSync(staging, { recursive: true, force: true });
-    throw err;
-  }
-};
-
 export let copyCache = async (cacheName: string, dest: string) => {
   let source = path.join(getGlobalCacheDir(), "packages", cacheName);
   let staging = createStagingDir(dest);
@@ -183,18 +163,49 @@ export let cacheSize = async () => {
   return (size / 1024 / 1024).toFixed(2) + " MB";
 };
 
-export let cleanCache = async () => {
-  if (
-    !getGlobalCacheDir().endsWith("mops/cache") &&
-    !getGlobalCacheDir().endsWith("/mops") &&
-    !getGlobalCacheDir().endsWith("/mops/" + getNetwork())
-  ) {
-    throw new Error("Invalid cache directory: " + getGlobalCacheDir());
+// Refuse to recursively delete anything that is not the mops cache. The dir
+// must sit inside `globalCacheDir` and its trailing segments must be `mops`,
+// `mops/cache` (Windows), each optionally followed by the network segment.
+// Separators are compared per-segment because `path.join` yields backslashes
+// on Windows.
+export function assertGlobalCacheDir(dir: string, cacheRoot = globalCacheDir) {
+  let resolved = path.resolve(dir);
+  let base = path.resolve(cacheRoot);
+  let inBase =
+    resolved === base ||
+    resolved.startsWith(base + "/") ||
+    resolved.startsWith(base + "\\");
+
+  let segments = resolved.split(/[\\/]+/).filter(Boolean);
+  let network = getNetwork();
+  if (network !== "ic" && segments.at(-1) === network) {
+    segments.pop();
+  }
+  if (segments.at(-1) === "cache") {
+    segments.pop();
   }
 
-  // local cache
-  fs.rmSync(path.join(getRootDir(), ".mops"), { recursive: true, force: true });
+  if (!inBase || segments.at(-1) !== "mops" || segments.length < 2) {
+    throw new Error("Invalid cache directory: " + resolved);
+  }
+}
+
+type CleanCacheOptions = {
+  // Leave the project's `.mops` directory alone.
+  global?: boolean;
+};
+
+export let cleanCache = async ({ global = false }: CleanCacheOptions = {}) => {
+  let globalCache = getGlobalCacheDir();
+  assertGlobalCacheDir(globalCache);
+
+  // local cache — outside a project `getRootDir()` is empty, which would
+  // target `.mops` in the current working directory
+  let rootDir = getRootDir();
+  if (!global && rootDir) {
+    fs.rmSync(path.join(rootDir, ".mops"), { recursive: true, force: true });
+  }
 
   // global cache
-  fs.rmSync(getGlobalCacheDir(), { recursive: true, force: true });
+  fs.rmSync(globalCache, { recursive: true, force: true });
 };

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -333,9 +333,13 @@ program
   .command("cache")
   .description("Manage cache")
   .addArgument(new Argument("<sub>").choices(["size", "clean", "show"]))
-  .action(async (sub) => {
+  .option(
+    "--global",
+    "cache clean: clean only the global cache, keep the project's .mops directory",
+  )
+  .action(async (sub, options) => {
     if (sub == "clean") {
-      await cleanCache();
+      await cleanCache(options);
       console.log("Cache cleaned");
     } else if (sub == "size") {
       let size = await cacheSize();
@@ -799,8 +803,12 @@ program
   .command("sync")
   .description("Add missing packages and remove unused packages")
   .addOption(legacyLockOption())
-  .action(async () => {
-    await sync();
+  .option(
+    "--dry-run",
+    "Print what would be added and removed without changing mops.toml, the local cache or mops.lock",
+  )
+  .action(async (options) => {
+    await sync(options);
   });
 
 // outdated

--- a/cli/commands/remove.ts
+++ b/cli/commands/remove.ts
@@ -127,8 +127,12 @@ export async function remove(
     let cacheName = getDepCacheName(dep.name, depValue);
     let localCacheDir = path.join(getRootDir(), ".mops", cacheName);
     if (localCacheDir && fs.existsSync(localCacheDir)) {
-      dryRun || deleteSync([localCacheDir], { force: true });
-      verbose && console.log(`Removed local cache ${localCacheDir}`);
+      if (dryRun) {
+        verbose && console.log(`Would remove local cache ${localCacheDir}`);
+      } else {
+        deleteSync([localCacheDir], { force: true });
+        verbose && console.log(`Removed local cache ${localCacheDir}`);
+      }
     }
   }
 
@@ -139,7 +143,17 @@ export async function remove(
   if (dev && config["dev-dependencies"]) {
     delete config["dev-dependencies"][name];
   }
-  dryRun || writeConfig(config);
+  // A dry run must not touch mops.toml, the local cache or mops.lock — the
+  // lockfile is rewritten by `checkIntegrity` even when it was only stale.
+  if (dryRun) {
+    console.log(
+      chalk.yellow("Would remove package ") +
+        `${name} = "${pkgDetails.repo || pkgDetails.path || version}"`,
+    );
+    return;
+  }
+
+  writeConfig(config);
 
   await syncLocalCache();
   await checkIntegrity(lock);

--- a/cli/commands/sync.ts
+++ b/cli/commands/sync.ts
@@ -8,52 +8,158 @@ import { remove } from "./remove.js";
 import { checkIntegrity } from "../integrity.js";
 import { toolchain } from "./toolchain/index.js";
 import { MOTOKO_IGNORE_PATTERNS } from "../constants.js";
-import { getDepName } from "../helpers/get-dep-name.js";
 
-export async function sync() {
+export type SyncOptions = {
+  dryRun?: boolean;
+};
+
+export type UsedPackages = {
+  prod: Set<string>;
+  dev: Set<string>;
+};
+
+export type DeclaredPackages = {
+  deps: Set<string>;
+  devDeps: Set<string>;
+};
+
+export type SyncPlan = {
+  add: { name: string; dev: boolean }[];
+  remove: { name: string; dev: boolean }[];
+};
+
+// Same directory shapes `mops test` and `mops bench` collect from.
+const DEV_SOURCE_PATTERNS = ["**/test?(s)/**/*.mo", "**/bench?(mark)/**/*.mo"];
+
+export async function sync({ dryRun = false }: SyncOptions = {}) {
   if (!checkConfigFile()) {
     return;
   }
 
-  let missing = await getMissingPackages();
-  let unused = await getUnusedPackages();
-
-  missing.length &&
-    console.log(`${chalk.yellow("Missing packages:")} ${missing.join(", ")}`);
-  unused.length &&
-    console.log(`${chalk.yellow("Unused packages:")} ${unused.join(", ")}`);
-
+  let used = await getUsedPackages();
   let config = readConfig();
-  let deps = new Set(Object.keys(config.dependencies || {}));
-  let devDeps = new Set(Object.keys(config["dev-dependencies"] || {}));
+  let declared = {
+    deps: new Set(Object.keys(config.dependencies || {})),
+    devDeps: new Set(Object.keys(config["dev-dependencies"] || {})),
+  };
+  let plan = computeSyncPlan(used, declared);
 
-  // add missing packages
-  for (let pkg of missing) {
-    await add(pkg, { lock: "skip" });
+  let names = (entries: { name: string }[]) =>
+    [...new Set(entries.map((entry) => entry.name))].join(", ");
+
+  plan.add.length &&
+    console.log(`${chalk.yellow("Missing packages:")} ${names(plan.add)}`);
+  plan.remove.length &&
+    console.log(`${chalk.yellow("Unused packages:")} ${names(plan.remove)}`);
+
+  if (dryRun) {
+    for (let { name, dev } of plan.add) {
+      console.log(chalk.green("Would add ") + name + (dev ? " (dev)" : ""));
+    }
+    for (let { name, dev } of plan.remove) {
+      console.log(chalk.red("Would remove ") + name + (dev ? " (dev)" : ""));
+    }
+    if (!plan.add.length && !plan.remove.length) {
+      console.log("Everything is in sync");
+    }
+    return;
   }
 
-  // remove unused packages
-  for (let pkg of unused) {
-    let dev = devDeps.has(pkg) && !deps.has(pkg);
-    await remove(pkg, { dev, lock: "skip" });
+  // `asName` keeps the declared key intact — `add` otherwise splits a pinned
+  // alias like `map@8.1.0` and writes it back under the bare `map` key.
+  for (let { name, dev } of plan.add) {
+    await add(name, { dev, lock: "skip" }, name);
+  }
+
+  for (let { name, dev } of plan.remove) {
+    await remove(name, { dev, lock: "skip" });
   }
 
   await checkIntegrity();
 }
 
-async function getUsedPackages(): Promise<string[]> {
-  let rootDir = getRootDir();
-  let mocPath = await toolchain.bin("moc");
+// `mo:map@8.1.0/Map` -> `map@8.1.0`. An import names the mops.toml key
+// verbatim, pinned alias included, so it must not be reduced to the base
+// package name.
+export function parseImportedPackage(dep: string): string | undefined {
+  let trimmed = dep.trim();
+  if (
+    !trimmed.startsWith("mo:") ||
+    trimmed.startsWith("mo:prim") ||
+    trimmed.startsWith("mo:⛔")
+  ) {
+    return undefined;
+  }
+  return trimmed.replace(/^mo:([^/]+).*$/, "$1") || undefined;
+}
 
-  let files = globSync("**/*.mo", {
+export function computeSyncPlan(
+  used: UsedPackages,
+  declared: DeclaredPackages,
+): SyncPlan {
+  let plan: SyncPlan = { add: [], remove: [] };
+  let isDeclared = (name: string) =>
+    declared.deps.has(name) || declared.devDeps.has(name);
+  let isUsed = (name: string) => used.prod.has(name) || used.dev.has(name);
+
+  for (let name of used.prod) {
+    if (!isDeclared(name)) {
+      plan.add.push({ name, dev: false });
+    }
+  }
+  for (let name of used.dev) {
+    if (!isDeclared(name) && !used.prod.has(name)) {
+      plan.add.push({ name, dev: true });
+    }
+  }
+
+  // A name declared in both sections is unused in both, so drop both entries.
+  for (let name of declared.deps) {
+    if (!isUsed(name)) {
+      plan.remove.push({ name, dev: false });
+    }
+  }
+  for (let name of declared.devDeps) {
+    if (!isUsed(name)) {
+      plan.remove.push({ name, dev: true });
+    }
+  }
+
+  return plan;
+}
+
+// Motoko sources of the project, split by whether they only ship as tests or
+// benchmarks.
+export function getSourceFiles(rootDir: string): {
+  prod: string[];
+  dev: string[];
+} {
+  let globOptions = {
     cwd: rootDir,
     nocase: true,
     ignore: MOTOKO_IGNORE_PATTERNS,
-  });
+  };
+  let devFiles = new Set(globSync(DEV_SOURCE_PATTERNS, globOptions));
+  let files = globSync("**/*.mo", globOptions);
+  return {
+    prod: files.filter((file) => !devFiles.has(file)),
+    dev: files.filter((file) => devFiles.has(file)),
+  };
+}
 
-  let packages: Set<string> = new Set();
+async function getUsedPackages(): Promise<UsedPackages> {
+  let rootDir = getRootDir();
+  let mocPath = await toolchain.bin("moc");
+
+  let sourceFiles = getSourceFiles(rootDir);
+  let devFiles = new Set(sourceFiles.dev);
+  let files = [...sourceFiles.prod, ...sourceFiles.dev];
+
+  let used: UsedPackages = { prod: new Set(), dev: new Set() };
 
   for (let file of files) {
+    let target = devFiles.has(file) ? used.dev : used.prod;
+
     let deps: string[] = execSync(
       `${mocPath} --print-deps ${path.join(rootDir, file)}`,
     )
@@ -62,37 +168,12 @@ async function getUsedPackages(): Promise<string[]> {
       .split("\n");
 
     for (let dep of deps) {
-      if (
-        dep.startsWith("mo:") &&
-        !dep.startsWith("mo:prim") &&
-        !dep.startsWith("mo:⛔")
-      ) {
-        packages.add(dep.replace(/^mo:([^/]+).*$/, "$1"));
+      let pkg = parseImportedPackage(dep);
+      if (pkg) {
+        target.add(pkg);
       }
     }
   }
 
-  return [...packages];
-}
-
-async function getMissingPackages(): Promise<string[]> {
-  let config = readConfig();
-  let allDepNames = new Set(
-    [
-      ...Object.keys(config.dependencies || {}),
-      ...Object.keys(config["dev-dependencies"] || {}),
-    ].map((key) => getDepName(key)),
-  );
-  let used = await getUsedPackages();
-  return used.filter((pkg) => !allDepNames.has(pkg));
-}
-
-async function getUnusedPackages(): Promise<string[]> {
-  let config = readConfig();
-  let allDeps = [
-    ...Object.keys(config.dependencies || {}),
-    ...Object.keys(config["dev-dependencies"] || {}),
-  ];
-  let used = new Set(await getUsedPackages());
-  return allDeps.filter((key) => !used.has(getDepName(key)));
+  return used;
 }

--- a/cli/tests/cache-clean.test.ts
+++ b/cli/tests/cache-clean.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// `api/actors` pulls in the generated `*.did.js` declarations, which the ESM
+// `.js` -> extensionless moduleNameMapper resolves to the raw `.did` files.
+jest.unstable_mockModule("../api/actors.js", () => ({
+  mainActor: jest.fn(),
+  mainOnewayCall: jest.fn(),
+  storageActor: jest.fn(),
+}));
+
+// `mops.ts` derives `globalCacheDir` at import time.
+const cacheHome = fs.realpathSync(
+  fs.mkdtempSync(path.join(os.tmpdir(), "mops-cache-clean-")),
+);
+process.env["XDG_CACHE_HOME"] = cacheHome;
+
+const { assertGlobalCacheDir, cleanCache, show } = await import("../cache.js");
+
+const posixCache = "/home/u/.cache/mops";
+const macCache = "/Users/u/Library/Caches/mops";
+// `path.join` yields backslashes on Windows, which the old `endsWith("mops/cache")`
+// guard could never match — `mops cache clean` threw there unconditionally.
+const winCache = "C:\\Users\\u\\AppData\\Local\\mops\\cache";
+
+describe("assertGlobalCacheDir", () => {
+  afterEach(() => {
+    delete process.env["MOPS_NETWORK"];
+  });
+
+  test("accepts the cache dir on every platform layout", () => {
+    expect(() => assertGlobalCacheDir(posixCache, posixCache)).not.toThrow();
+    expect(() => assertGlobalCacheDir(macCache, macCache)).not.toThrow();
+    expect(() => assertGlobalCacheDir(winCache, winCache)).not.toThrow();
+  });
+
+  test("accepts the network-scoped cache dir", () => {
+    process.env["MOPS_NETWORK"] = "local";
+    expect(() =>
+      assertGlobalCacheDir(posixCache + "/local", posixCache),
+    ).not.toThrow();
+    expect(() =>
+      assertGlobalCacheDir(winCache + "\\local", winCache),
+    ).not.toThrow();
+  });
+
+  test("rejects a network segment that is not the current network", () => {
+    expect(() =>
+      assertGlobalCacheDir(posixCache + "/local", posixCache),
+    ).toThrow(/Invalid cache directory/);
+  });
+
+  test("rejects anything but the cache root", () => {
+    expect(() =>
+      assertGlobalCacheDir(posixCache + "/packages", posixCache),
+    ).toThrow(/Invalid cache directory/);
+    expect(() => assertGlobalCacheDir("/home/u/.cache", posixCache)).toThrow(
+      /Invalid cache directory/,
+    );
+    expect(() => assertGlobalCacheDir("/tmp/something", posixCache)).toThrow(
+      /Invalid cache directory/,
+    );
+  });
+
+  test("rejects a traversing network name", () => {
+    process.env["MOPS_NETWORK"] = "../..";
+    expect(() =>
+      assertGlobalCacheDir(path.join(posixCache, "../.."), posixCache),
+    ).toThrow(/Invalid cache directory/);
+  });
+});
+
+describe("cleanCache", () => {
+  const seed = () => {
+    let globalCache = show();
+    fs.mkdirSync(path.join(globalCache, "packages", "core@1.0.0"), {
+      recursive: true,
+    });
+
+    let project = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "mops-project-")),
+    );
+    fs.writeFileSync(path.join(project, "mops.toml"), "[dependencies]\n");
+    fs.mkdirSync(path.join(project, ".mops", "core@1.0.0"), {
+      recursive: true,
+    });
+    return { globalCache, project };
+  };
+
+  const inProject = async (project: string, fn: () => Promise<void>) => {
+    let cwd = process.cwd();
+    process.chdir(project);
+    try {
+      await fn();
+    } finally {
+      process.chdir(cwd);
+    }
+  };
+
+  test("removes the global cache and the project's .mops", async () => {
+    let { globalCache, project } = seed();
+    await inProject(project, () => cleanCache());
+    expect(fs.existsSync(globalCache)).toBe(false);
+    expect(fs.existsSync(path.join(project, ".mops"))).toBe(false);
+  });
+
+  test("global keeps the project's .mops", async () => {
+    let { globalCache, project } = seed();
+    await inProject(project, () => cleanCache({ global: true }));
+    expect(fs.existsSync(globalCache)).toBe(false);
+    expect(fs.existsSync(path.join(project, ".mops", "core@1.0.0"))).toBe(true);
+  });
+});

--- a/cli/tests/remove-dry-run.test.ts
+++ b/cli/tests/remove-dry-run.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { cli, useTempFixtures } from "./helpers";
+
+// `--dry-run` used to delete the local cache entries, print "Package removed",
+// and rewrite an already-stale mops.lock through checkIntegrity.
+describe("remove --dry-run", () => {
+  jest.setTimeout(120_000);
+
+  const makeTempFixture = useTempFixtures(
+    path.join(import.meta.dirname, "remove-dry-run"),
+  );
+
+  // deliberately disagrees with mops.toml, so any lock maintenance rewrites it
+  const staleLock = JSON.stringify({
+    version: 3,
+    deps: { core: "0.9.0" },
+    graph: {},
+  });
+
+  test("changes nothing on disk and says so", async () => {
+    const cwd = await makeTempFixture("basic");
+    const toml = path.join(cwd, "mops.toml");
+    const lock = path.join(cwd, "mops.lock");
+    const localCache = path.join(cwd, ".mops", "core@1.0.0");
+
+    writeFileSync(lock, staleLock);
+    mkdirSync(localCache, { recursive: true });
+    writeFileSync(path.join(localCache, "mops.toml"), "[package]\n");
+
+    const tomlBefore = readFileSync(toml, "utf8");
+
+    const res = await cli(["remove", "core", "--dry-run", "--verbose"], {
+      cwd,
+      env: { CI: "1" },
+    });
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toMatch(/Would remove package core = "1\.0\.0"/);
+    expect(res.stdout).toMatch(/Would remove local cache .*core@1\.0\.0/);
+    expect(res.stdout).not.toMatch(/Package removed/);
+
+    expect(readFileSync(toml, "utf8")).toBe(tomlBefore);
+    expect(readFileSync(lock, "utf8")).toBe(staleLock);
+    expect(existsSync(path.join(localCache, "mops.toml"))).toBe(true);
+  });
+
+  test("reports an unknown package without touching the lock", async () => {
+    const cwd = await makeTempFixture("basic");
+    const lock = path.join(cwd, "mops.lock");
+    writeFileSync(lock, staleLock);
+
+    const res = await cli(["remove", "nope", "--dry-run"], {
+      cwd,
+      env: { CI: "1" },
+    });
+
+    expect(res.stdout).toMatch(/No dependency to remove "nope"/);
+    expect(readFileSync(lock, "utf8")).toBe(staleLock);
+  });
+});

--- a/cli/tests/remove-dry-run/basic/mops.toml
+++ b/cli/tests/remove-dry-run/basic/mops.toml
@@ -1,0 +1,2 @@
+[dependencies]
+core = "1.0.0"

--- a/cli/tests/sync-plan.test.ts
+++ b/cli/tests/sync-plan.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// `api/actors` pulls in the generated `*.did.js` declarations, which the ESM
+// `.js` -> extensionless moduleNameMapper resolves to the raw `.did` files.
+// Only the pure planning helpers are under test here.
+jest.unstable_mockModule("../api/actors.js", () => ({
+  mainActor: jest.fn(),
+  mainOnewayCall: jest.fn(),
+  storageActor: jest.fn(),
+}));
+
+const { computeSyncPlan, getSourceFiles, parseImportedPackage } =
+  await import("../commands/sync.js");
+
+type SyncPlan = {
+  add: { name: string; dev: boolean }[];
+  remove: { name: string; dev: boolean }[];
+};
+
+const used = (prod: string[] = [], dev: string[] = []) => ({
+  prod: new Set(prod),
+  dev: new Set(dev),
+});
+
+const declared = (deps: string[] = [], devDeps: string[] = []) => ({
+  deps: new Set(deps),
+  devDeps: new Set(devDeps),
+});
+
+const plan = (p: SyncPlan) => ({
+  add: p.add.map((e) => `${e.name}${e.dev ? " (dev)" : ""}`),
+  remove: p.remove.map((e) => `${e.name}${e.dev ? " (dev)" : ""}`),
+});
+
+describe("parseImportedPackage", () => {
+  test("keeps the pinned alias", () => {
+    expect(parseImportedPackage("mo:map@8.1.0/Map")).toBe("map@8.1.0");
+    expect(parseImportedPackage("mo:map@8.1.0")).toBe("map@8.1.0");
+  });
+
+  test("returns the package name of a plain import", () => {
+    expect(parseImportedPackage("mo:core/Array")).toBe("core");
+    expect(parseImportedPackage("mo:core")).toBe("core");
+    expect(parseImportedPackage("mo:core/Array\r")).toBe("core");
+  });
+
+  test("skips non-package deps", () => {
+    expect(parseImportedPackage("mo:prim")).toBeUndefined();
+    expect(parseImportedPackage("mo:⛔")).toBeUndefined();
+    expect(parseImportedPackage("canister:foo")).toBeUndefined();
+    expect(parseImportedPackage("/abs/path/Lib.mo")).toBeUndefined();
+  });
+});
+
+// A pinned alias (`"map@8.1.0" = "8.1.0"`) is imported as `mo:map@8.1.0`, so
+// the used set and the declared keys live in the same namespace. Reducing
+// either side to the base name made sync add-then-remove the `map` key.
+describe("computeSyncPlan pinned aliases", () => {
+  test("alias declared and used is left alone", () => {
+    expect(
+      plan(computeSyncPlan(used(["map@8.1.0"]), declared(["map@8.1.0"]))),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  test("alias declared but unused is removed, and only the alias key", () => {
+    expect(plan(computeSyncPlan(used([]), declared(["map@8.1.0"])))).toEqual({
+      add: [],
+      remove: ["map@8.1.0"],
+    });
+  });
+
+  test("base name and alias both declared and both used", () => {
+    expect(
+      plan(
+        computeSyncPlan(
+          used(["map", "map@8.1.0"]),
+          declared(["map", "map@8.1.0"]),
+        ),
+      ),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  test("using the base name does not keep an unused alias alive", () => {
+    expect(
+      plan(computeSyncPlan(used(["map"]), declared(["map", "map@8.1.0"]))),
+    ).toEqual({ add: [], remove: ["map@8.1.0"] });
+  });
+
+  test("an undeclared alias import is added under its alias key", () => {
+    expect(
+      plan(computeSyncPlan(used(["map", "map@8.1.0"]), declared(["map"]))),
+    ).toEqual({ add: ["map@8.1.0"], remove: [] });
+  });
+
+  test("a plain package with no alias round-trips", () => {
+    expect(plan(computeSyncPlan(used(["core"]), declared(["core"])))).toEqual({
+      add: [],
+      remove: [],
+    });
+  });
+});
+
+describe("getSourceFiles", () => {
+  const makeProject = (files: string[]) => {
+    let root = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "mops-sync-sources-")),
+    );
+    for (let file of files) {
+      fs.mkdirSync(path.join(root, path.dirname(file)), { recursive: true });
+      fs.writeFileSync(path.join(root, file), "");
+    }
+    return root;
+  };
+
+  test("classifies test and bench sources as dev", () => {
+    let root = makeProject([
+      "src/Main.mo",
+      "test/main.test.mo",
+      "test/utils.mo",
+      "tests/nested/other.test.mo",
+      "bench/main.bench.mo",
+      "benchmark/other.bench.mo",
+      "src/latest/Contest.mo",
+      "node_modules/pkg/Ignored.mo",
+      ".mops/dep/Ignored.mo",
+    ]);
+    let files = getSourceFiles(root);
+    expect(files.prod.sort()).toEqual(["src/Main.mo", "src/latest/Contest.mo"]);
+    expect(files.dev.sort()).toEqual([
+      "bench/main.bench.mo",
+      "benchmark/other.bench.mo",
+      "test/main.test.mo",
+      "test/utils.mo",
+      "tests/nested/other.test.mo",
+    ]);
+  });
+});
+
+describe("computeSyncPlan dev classification", () => {
+  test("a package used only from test/bench sources becomes a dev dependency", () => {
+    expect(plan(computeSyncPlan(used([], ["test"]), declared()))).toEqual({
+      add: ["test (dev)"],
+      remove: [],
+    });
+  });
+
+  test("a package used in both goes to dependencies", () => {
+    expect(plan(computeSyncPlan(used(["core"], ["core"]), declared()))).toEqual(
+      {
+        add: ["core"],
+        remove: [],
+      },
+    );
+  });
+
+  test("dev usage keeps a production dependency declared", () => {
+    expect(
+      plan(computeSyncPlan(used([], ["core"]), declared(["core"]))),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  test("production usage keeps a dev dependency declared", () => {
+    expect(
+      plan(computeSyncPlan(used(["core"]), declared([], ["core"]))),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  test("an unused package declared in both sections is removed from both", () => {
+    expect(
+      plan(computeSyncPlan(used([]), declared(["core"], ["core"]))),
+    ).toEqual({ add: [], remove: ["core", "core (dev)"] });
+  });
+
+  test("an unused dev dependency is removed as dev", () => {
+    expect(plan(computeSyncPlan(used([]), declared([], ["test"])))).toEqual({
+      add: [],
+      remove: ["test (dev)"],
+    });
+  });
+});

--- a/docs/docs/cli/1-deps/05-mops-sync.md
+++ b/docs/docs/cli/1-deps/05-mops-sync.md
@@ -13,4 +13,32 @@ Analyze source code and:
 mops sync
 ```
 
-The [lockfile](../../10-mops.lock.md) is always kept in sync — there is no flag to opt out.
+`mops sync` compiles nothing, but it does read your imports with `moc`, so it requires a pinned [`[toolchain] moc`](../5-toolchain/01-toolchain-overview.md).
+
+### `--dry-run`
+
+Print what would be added and removed without touching `mops.toml`, the local cache or the [lockfile](../../10-mops.lock.md).
+
+```
+mops sync --dry-run
+```
+
+```
+Would add core
+Would remove itertools
+Would add fuzz (dev)
+```
+
+## Dev dependencies
+
+A package imported only from `test`, `tests`, `bench` or `benchmark` directories is added to `[dev-dependencies]`. A package imported anywhere else is added to `[dependencies]`, even if it is also used in tests.
+
+Packages that are already declared are never moved between the two sections — `mops sync` only classifies packages it adds.
+
+## Pinned aliases
+
+[Pinned aliases](../../articles/00-dependency-version-pinning.md) are matched against imports verbatim, so `mo:map@8.1.0` corresponds to the `"map@8.1.0"` key and `mo:map` to the `map` key. The two are tracked independently: removing one never rewrites the other.
+
+## Lockfile
+
+The [lockfile](../../10-mops.lock.md) is always kept in sync — there is no flag to opt out, except `--dry-run`, which writes nothing at all.

--- a/docs/docs/cli/7-misc/03-mops-cache.md
+++ b/docs/docs/cli/7-misc/03-mops-cache.md
@@ -24,3 +24,11 @@ Print global cache size.
 ### `mops cache clean`
 
 Clean global and local cache directories.
+
+Pass `--global` to clean only the global cache and keep the project's `.mops` directory:
+
+```
+mops cache clean --global
+```
+
+Run outside a project (no `mops.toml` in any parent directory), `mops cache clean` only cleans the global cache.


### PR DESCRIPTION
`mops sync` could silently delete a dependency. Given the pinned-alias layout the docs recommend:

```toml
map = "9.0.1"
"map@8.1.0" = "8.1.0"
```

sync built its "used" set from imports (`mo:map@8.1.0/Map` → `map@8.1.0`) but its "declared" set through `getDepName`, which collapses both keys to `map`. The two sets lived in different namespaces, so the alias was reported as *both* missing and unused. Adding it split on `@` and wrote `map = "8.1.0"`, clobbering `9.0.1`; and because both sets are computed before any mutation, one run could add and then remove, leaving the project with no `map` at all.

```
$ mops sync
Before: map = "8.1.0"        # 9.0.1 overwritten, alias key gone
After:  map = "9.0.1"        # unchanged
        "map@8.1.0" = "8.1.0"
```

It evaded detection because `mops sync` has no test coverage at all — `cli.test.ts` notes that add/remove/update/sync "all route through the same checkIntegrity code path tested above", which is true of the lock write but not of the set arithmetic that decides what to add and remove.

Three smaller `sync` defects came out of covering it: packages imported only from `test`/`bench` sources were added to `[dependencies]`; a package declared in *both* sections was only ever removed from `[dependencies]`, leaving a dangling entry the next run reported again; and `moc --print-deps` was spawned twice per file because the used-set was recomputed for the missing and unused queries independently.

## `mops remove --dry-run` was not a dry run

It deleted local cache directories, and ran `checkIntegrity`, which rewrites `mops.lock` whenever it was already stale. It also printed `Package removed …` as though it had happened.

## `mops cache clean` was broken on Windows, always

The safety guard compared a `path.join` result against the literal suffix `mops/cache`. On Windows `path.join` yields backslashes, so the guard could never match and the command failed with "Invalid cache directory" on every run. Network-scoped directories (`mops/cache/<network>`) matched no clause either.

The replacement is separator-agnostic and strictly *narrower* than what it replaces: it also requires the target to be contained in the global cache root, so a traversing `MOPS_NETWORK` is rejected rather than accepted on a suffix match. Separately, when run outside a project `getRootDir()` returns empty and `path.join("", ".mops")` resolved to `./.mops` in whatever directory the user happened to be standing in — that local delete is now skipped.

## Migration

`mops cache clean` still removes the project's `.mops` as documented; the new `--global` opts out. No other behaviour changes for existing invocations.

## Scope

First of three stacked PRs splitting the Cargo/pnpm audit work, which was originally opened as [#724](https://github.com/caffeinelabs/mops/pull/724). This one is the self-contained command fixes and touches no install, resolution or integrity code. Remaining audit findings are catalogued in [#723](https://github.com/caffeinelabs/mops/issues/723).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
