### PR TITLE
ci: stop freezing the mops package cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,22 @@ jobs:
 
       - uses: ./.github/actions/cache-rust-wasm
 
+      # Keyed on everything the pre-cache step below actually downloads: the
+      # root pins, every fixture's pins and deps, and the compiled-in default
+      # PocketIC version. Keying on `mops.toml` alone froze this cache — that
+      # file rarely changes, so every run hit the primary key, `actions/cache`
+      # skipped the save ("not saving cache"), and toolchains added afterwards
+      # were re-downloaded forever.
+      #
+      # The key is also namespaced per workflow. `mops test` jobs never install
+      # the fixtures, so sharing one key let them win the save race and publish
+      # a cache without the fixture toolchains in it.
       - name: Cache mops packages
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          key: mops-packages-${{ runner.os }}-${{ hashFiles('mops.toml') }}
+          key: mops-ci-${{ runner.os }}-${{ hashFiles('mops.toml', 'cli/tests/**/mops.toml', 'cli/commands/toolchain/pocket-ic-versions.ts') }}
           restore-keys: |
-            mops-packages-${{ runner.os }}-${{ hashFiles('mops.toml') }}
-            mops-packages-${{ runner.os }}
+            mops-ci-${{ runner.os }}-
           path: |
             ~/.cache/mops
             ~/Library/Caches/mops

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -37,13 +37,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
+      # Namespaced separately from the CI workflow's cache: this job only ever
+      # installs the root manifest, so it must not be able to publish a cache
+      # that CI's fixture-heavy jobs would then restore as complete.
       - name: Cache mops packages
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          key: mops-packages-${{ runner.os }}-${{ hashFiles('mops.toml') }}
+          key: mops-repo-tests-${{ runner.os }}-${{ hashFiles('mops.toml') }}
           restore-keys: |
-            mops-packages-${{ runner.os }}-${{ hashFiles('mops.toml') }}
-            mops-packages-${{ runner.os }}
+            mops-repo-tests-${{ runner.os }}-
           path: |
             ~/.cache/mops
             ~/Library/Caches/mops


### PR DESCRIPTION
Every CI job re-downloads `moc 1.3.0`, `moc 1.10.0`, `pocket-ic 12.0.0`, `pocket-ic 14.0.0`, `core@1.0.0` and `core@2.0.0` — roughly 45s of network per job, in a step whose whole purpose is to be cached.

The cache key was `hashFiles('mops.toml')`. That file rarely changes, so nearly every run hit the primary key, and `actions/cache` only writes on a *miss*. The logs said so plainly, on every run:

```
Cache hit occurred on the primary key mops-packages-Linux-3fb6f2…, not saving cache.
```

So the cache was frozen at whatever it held the first time that key was saved, and every toolchain or fixture dependency added afterwards fell permanently outside it. The restore still reported a 85 MB hit, which is what made this invisible — the cache was warm, just missing everything the tests had grown to need since.

Keying on what the pre-cache step actually downloads fixes it: the root pins, every fixture's pins and deps, and the compiled-in `DEFAULT_POCKET_IC_VERSION`.

## Why the frozen cache was also an incomplete one

`mops-test.yml` used the byte-identical key and runs concurrently, but it only ever runs `mops install` against the root manifest — it never touches `cli/tests/**`. Whenever one of its nine jobs won the save race, the published cache contained no fixture toolchains at all. The two workflows now own separately namespaced keys, so neither can publish a cache the other would restore as complete.

## What is unchanged

No job gains or loses coverage, and the pre-cache step keeps installing every fixture — that exhaustiveness is what makes the CI cache correct for any job that restores it. The first run on each branch pays a one-time full download to seed the new key.