### PR TITLE
test(cli): split build.test.ts by concern

### DIFF
--- a/cli/tests/__snapshots__/build-check-deploy.test.ts.snap
+++ b/cli/tests/__snapshots__/build-check-deploy.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`build check-deploy [build].check-deploy installs the built Wasm on PocketIC 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": "build canister main
+check deploy canister main
+
+✓ Built 1 canister successfully",
+}
+`;
+
+exports[`build check-deploy --check-deploy installs the built Wasm on PocketIC 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": "build canister main
+check deploy canister main
+
+✓ Built 1 canister successfully",
+}
+`;

--- a/cli/tests/__snapshots__/build.test.ts.snap
+++ b/cli/tests/__snapshots__/build.test.ts.snap
@@ -1,27 +1,5 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`build [build].check-deploy installs the built Wasm on PocketIC 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": "build canister main
-check deploy canister main
-
-✓ Built 1 canister successfully",
-}
-`;
-
-exports[`build --check-deploy installs the built Wasm on PocketIC 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": "build canister main
-check deploy canister main
-
-✓ Built 1 canister successfully",
-}
-`;
-
 exports[`build error 1`] = `
 {
   "exitCode": 0,

--- a/cli/tests/build-check-deploy.test.ts
+++ b/cli/tests/build-check-deploy.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { linkSync, rmSync } from "node:fs";
+import path from "path";
+import { cleanFixture } from "./build-helpers";
+import { cli, cliSnapshot } from "./helpers";
+
+describe("build check-deploy", () => {
+  // Several pocket-ic builds per test; slow CI can exceed 60s default.
+  jest.setTimeout(120_000);
+
+  test("[build].check-deploy installs the built Wasm on PocketIC", async () => {
+    const cwd = path.join(import.meta.dirname, "build/check-deploy-config");
+    try {
+      await cliSnapshot(["build"], { cwd }, 0);
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--check-deploy installs the built Wasm on PocketIC", async () => {
+    const cwd = path.join(import.meta.dirname, "build/check-deploy");
+    try {
+      await cliSnapshot(["build", "--check-deploy"], { cwd }, 0);
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--check-deploy accepts a path-pinned PocketIC binary", async () => {
+    const versionCwd = path.join(import.meta.dirname, "build/check-deploy");
+    const cwd = path.join(import.meta.dirname, "build/check-deploy-path");
+    const localBin = path.join(cwd, "pocket-ic");
+    try {
+      const binResult = await cli(["toolchain", "bin", "pocket-ic"], {
+        cwd: versionCwd,
+      });
+      expect(binResult.exitCode).toBe(0);
+      rmSync(localBin, { force: true });
+      linkSync(binResult.stdout.trim(), localBin);
+
+      const result = await cli(["build", "--check-deploy"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch("check deploy canister main");
+    } finally {
+      rmSync(localBin, { force: true });
+      cleanFixture(cwd);
+    }
+  });
+
+  test("build without check-deploy config does not check deployment", async () => {
+    const cwd = path.join(import.meta.dirname, "build/check-deploy");
+    try {
+      const result = await cli(["build"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toMatch("check deploy canister");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--no-check-deploy overrides [build].check-deploy", async () => {
+    const cwd = path.join(import.meta.dirname, "build/check-deploy-config");
+    try {
+      const result = await cli(["build", "--no-check-deploy"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toMatch("check deploy canister");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--check-deploy reports Wasm memory limit failures", async () => {
+    const cwd = path.join(import.meta.dirname, "build/check-deploy-fail");
+    try {
+      const result = await cli(["build", "--check-deploy"], { cwd });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch("PocketIC deployment check failed");
+      expect(result.stderr).toMatch("Wasm memory limit");
+      expect(result.stderr).toMatch(
+        "Error code: CanisterWasmMemoryLimitExceeded",
+      );
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--check-deploy reports Candid encoding errors without a deployment label", async () => {
+    const cwd = path.join(
+      import.meta.dirname,
+      "build/check-deploy-invalid-arg",
+    );
+    try {
+      const result = await cli(["build", "--check-deploy"], { cwd });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch("Invalid initArg for canister main");
+      expect(result.stderr).not.toMatch("PocketIC deployment check failed");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--check-deploy preserves an ordinary installation failure", async () => {
+    const cwd = path.join(import.meta.dirname, "build/check-deploy-trap");
+    try {
+      const result = await cli(["build", "--check-deploy"], { cwd });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch("PocketIC deployment check failed");
+      expect(result.stderr).toMatch("assertion failed");
+      expect(result.stderr).toMatch("Error code: CanisterCalledTrap");
+      expect(result.stderr).not.toMatch("MOPS-CHECK-DEPLOY-SKIPPED");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--check-deploy preserves PocketIC startup failures", async () => {
+    const cwd = path.join(
+      import.meta.dirname,
+      "build/check-deploy-startup-fail",
+    );
+    try {
+      const result = await cli(["build", "--check-deploy"], { cwd });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch("PocketIC deployment check failed");
+      expect(result.stdout).not.toMatch("check deploy canister");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("check-deploy skips chains incompatible with empty state and checks siblings", async () => {
+    const cwd = path.join(
+      import.meta.dirname,
+      "build/check-deploy-incomplete-migrations",
+    );
+    try {
+      const result = await cli(["build"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toMatch("Warning [MOPS-CHECK-DEPLOY-SKIPPED]");
+      expect(result.stderr).toMatch("Canister: problematic");
+      expect(result.stderr).toMatch("Canister: problematic2");
+      expect(
+        result.stderr.match(/Fresh PocketIC deployment check did not run\./g),
+      ).toHaveLength(2);
+      expect(result.stderr).toMatch(
+        "moc reported that the generated stable state is incompatible with an empty canister",
+      );
+      expect(result.stderr).toMatch("Compatibility error");
+      expect(result.stdout).not.toMatch("check deploy canister problematic");
+      expect(result.stdout).not.toMatch("check deploy canister problematic2");
+      expect(result.stdout).toMatch("check deploy canister healthy");
+      expect(result.stdout).toMatch("check deploy canister aliased");
+      expect(result.stdout).toMatch("Built 4 canisters successfully");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--check-deploy rejects a legacy PocketIC pin", async () => {
+    const cwd = path.join(import.meta.dirname, "build/check-deploy-legacy");
+    const result = await cli(["build", "--check-deploy"], { cwd });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch("pins below 9.0.0 no longer work");
+    expect(result.stdout).toMatch("mops toolchain use pocket-ic 14.0.0");
+  });
+});

--- a/cli/tests/build-check-wasm.test.ts
+++ b/cli/tests/build-check-wasm.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import path from "path";
+import { cleanFixture } from "./build-helpers";
+import { cli } from "./helpers";
+
+describe("build check-wasm", () => {
+  // Several pocket-ic builds per test; slow CI can exceed 60s default.
+  jest.setTimeout(120_000);
+
+  test("over-limit IC0505 estimate continues to PocketIC", async () => {
+    const cwd = path.join(import.meta.dirname, "build/wasm-complexity");
+    try {
+      const result = await cli(["build"], { cwd });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch("Warning [MOPS-WASM-COMPLEXITY]");
+      expect(result.stderr).toMatch(
+        /Function: 0[\s\S]*Estimated complexity: 1,000,050[\s\S]*IC0505 limit: 1,000,000[\s\S]*Limit usage: 100\.0%[\s\S]*Instruction count: 20,001/,
+      );
+      expect(result.stderr).toMatch(
+        "Run `mops build --check-deploy` for authoritative PocketIC validation",
+      );
+      expect(result.stderr).toMatch("Error code: CanisterInvalidWasm");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--check-wasm analyzes Wasm without starting PocketIC", async () => {
+    const cwd = path.join(import.meta.dirname, "build/check-wasm-flag");
+    try {
+      const result = await cli(["build", "--check-wasm"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toMatch("Warning [MOPS-WASM-COMPLEXITY]");
+      expect(result.stdout).not.toMatch("check deploy canister");
+      expect(result.stdout).toMatch("Built 1 canister successfully");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--no-check-deploy leaves configured Wasm analysis enabled", async () => {
+    const cwd = path.join(import.meta.dirname, "build/wasm-complexity");
+    try {
+      const result = await cli(["build", "--no-check-deploy"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toMatch("Warning [MOPS-WASM-COMPLEXITY]");
+      expect(result.stdout).not.toMatch("check deploy canister");
+      expect(result.stdout).toMatch("Built 1 canister successfully");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--no-check-wasm leaves configured PocketIC validation enabled", async () => {
+    const cwd = path.join(import.meta.dirname, "build/wasm-complexity");
+    try {
+      const result = await cli(["build", "--no-check-wasm"], { cwd });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).not.toMatch("MOPS-WASM-COMPLEXITY");
+      expect(result.stderr).toMatch("Error code: CanisterInvalidWasm");
+      expect(result.stdout).toMatch("check deploy canister main");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("rejects an invalid wasmMemoryLimit without --check-deploy", async () => {
+    const cwd = path.join(import.meta.dirname, "build/invalid-memory-limit");
+    const result = await cli(["build"], { cwd });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(
+      "Invalid wasmMemoryLimit for canister main: expected a positive integer number of bytes",
+    );
+    expect(result.stderr).not.toMatch("PocketIC deployment check failed");
+  });
+});

--- a/cli/tests/build-helpers.ts
+++ b/cli/tests/build-helpers.ts
@@ -1,0 +1,16 @@
+import { rmSync } from "node:fs";
+import path from "path";
+
+/**
+ * Remove a build fixture's `.mops` directory, plus any extra paths a test
+ * created outside it (custom output dirs, stray artifacts, lockfiles).
+ *
+ * Shared by the `build*.test.ts` suites, which are split by concern so that no
+ * single file becomes the tail of the whole jest run.
+ */
+export function cleanFixture(cwd: string, ...extras: string[]) {
+  rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+  for (const p of extras) {
+    rmSync(p, { recursive: true, force: true });
+  }
+}

--- a/cli/tests/build-optimize.test.ts
+++ b/cli/tests/build-optimize.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import path from "path";
+import { cleanFixture } from "./build-helpers";
+import { cli } from "./helpers";
+
+describe("build optimize", () => {
+  // Several builds per test; slow CI can exceed 60s default.
+  jest.setTimeout(120_000);
+
+  test("[optimize] runs wasm-opt after build", async () => {
+    const cwd = path.join(import.meta.dirname, "build/optimize");
+    const stamp = path.join(cwd, ".mops/.build/.wasm-opt-ran");
+    try {
+      const result = await cli(["build", "--verbose"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).toMatch(/Optimized main\.wasm/);
+      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(true);
+      expect(existsSync(stamp)).toBe(true);
+    } finally {
+      cleanFixture(cwd);
+      rmSync(stamp, { force: true });
+    }
+  });
+
+  test("--no-optimize skips the wasm-opt pass", async () => {
+    const cwd = path.join(import.meta.dirname, "build/optimize");
+    const stamp = path.join(cwd, ".mops/.build/.wasm-opt-ran");
+    try {
+      const result = await cli(["build", "--no-optimize", "--verbose"], {
+        cwd,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).not.toMatch(/Optimized main\.wasm/);
+      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(true);
+      expect(existsSync(stamp)).toBe(false);
+    } finally {
+      cleanFixture(cwd);
+      rmSync(stamp, { force: true });
+    }
+  });
+
+  test("[optimize] fails the build when wasm-opt errors", async () => {
+    const cwd = path.join(import.meta.dirname, "build/optimize-fail");
+    try {
+      const result = await cli(["build"], { cwd });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/Failed to optimize main\.wasm/);
+      expect(result.stderr).toMatch("mock-wasm-opt: intentional failure");
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("[optimize] without a wasm-opt pin errors instead of pinning one", async () => {
+    const cwd = path.join(import.meta.dirname, "build/optimize-unpinned");
+    const manifest = path.join(cwd, "mops.toml");
+    const before = readFileSync(manifest, "utf8");
+    try {
+      const result = await cli(["build"], { cwd });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch("wasm-opt is not pinned");
+      expect(result.stderr).toMatch("mops toolchain use wasm-opt 131");
+      // The build must not rewrite the manifest it was handed.
+      expect(readFileSync(manifest, "utf8")).toBe(before);
+      // ...and must fail before compiling anything.
+      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(false);
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+
+  test("--no-optimize builds despite an unpinned wasm-opt", async () => {
+    const cwd = path.join(import.meta.dirname, "build/optimize-unpinned");
+    try {
+      const result = await cli(["build", "--no-optimize"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(true);
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
+});

--- a/cli/tests/build.test.ts
+++ b/cli/tests/build.test.ts
@@ -1,25 +1,17 @@
 import { describe, expect, jest, test } from "@jest/globals";
 import { execa } from "execa";
 import { createHash } from "node:crypto";
-import {
-  appendFileSync,
-  existsSync,
-  linkSync,
-  readFileSync,
-  rmSync,
-} from "node:fs";
+import { appendFileSync, existsSync, readFileSync, rmSync } from "node:fs";
 import path from "path";
+import { cleanFixture } from "./build-helpers";
 import { cli, cliSnapshot } from "./helpers";
 
 const distBin = path.resolve(import.meta.dirname, "../dist/bin/mops.js");
 
-function cleanFixture(cwd: string, ...extras: string[]) {
-  rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
-  for (const p of extras) {
-    rmSync(p, { recursive: true, force: true });
-  }
-}
-
+// Core build behaviour. The `[optimize]`, Wasm-analysis and PocketIC
+// check-deploy groups live in build-optimize / build-check-wasm /
+// build-check-deploy: jest parallelises across files, not within one, so a
+// single build suite made itself the tail of the entire run.
 describe("build", () => {
   // Several dfx/pocket-ic builds per test; slow CI can exceed 60s default.
   jest.setTimeout(120_000);
@@ -148,310 +140,16 @@ describe("build", () => {
     },
   );
 
-  test("[optimize] runs wasm-opt after build", async () => {
-    const cwd = path.join(import.meta.dirname, "build/optimize");
-    const stamp = path.join(cwd, ".mops/.build/.wasm-opt-ran");
-    try {
-      const result = await cli(["build", "--verbose"], { cwd });
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toMatch(/Optimized main\.wasm/);
-      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(true);
-      expect(existsSync(stamp)).toBe(true);
-    } finally {
-      cleanFixture(cwd);
-      rmSync(stamp, { force: true });
-    }
-  });
-
-  test("--no-optimize skips the wasm-opt pass", async () => {
-    const cwd = path.join(import.meta.dirname, "build/optimize");
-    const stamp = path.join(cwd, ".mops/.build/.wasm-opt-ran");
-    try {
-      const result = await cli(["build", "--no-optimize", "--verbose"], {
-        cwd,
-      });
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).not.toMatch(/Optimized main\.wasm/);
-      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(true);
-      expect(existsSync(stamp)).toBe(false);
-    } finally {
-      cleanFixture(cwd);
-      rmSync(stamp, { force: true });
-    }
-  });
-
-  test("over-limit IC0505 estimate continues to PocketIC", async () => {
-    const cwd = path.join(import.meta.dirname, "build/wasm-complexity");
-    try {
-      const result = await cli(["build"], { cwd });
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toMatch("Warning [MOPS-WASM-COMPLEXITY]");
-      expect(result.stderr).toMatch(
-        /Function: 0[\s\S]*Estimated complexity: 1,000,050[\s\S]*IC0505 limit: 1,000,000[\s\S]*Limit usage: 100\.0%[\s\S]*Instruction count: 20,001/,
-      );
-      expect(result.stderr).toMatch(
-        "Run `mops build --check-deploy` for authoritative PocketIC validation",
-      );
-      expect(result.stderr).toMatch("Error code: CanisterInvalidWasm");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--check-wasm analyzes Wasm without starting PocketIC", async () => {
-    const cwd = path.join(import.meta.dirname, "build/check-wasm-flag");
-    try {
-      const result = await cli(["build", "--check-wasm"], { cwd });
-      expect(result.exitCode).toBe(0);
-      expect(result.stderr).toMatch("Warning [MOPS-WASM-COMPLEXITY]");
-      expect(result.stdout).not.toMatch("check deploy canister");
-      expect(result.stdout).toMatch("Built 1 canister successfully");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--no-check-deploy leaves configured Wasm analysis enabled", async () => {
-    const cwd = path.join(import.meta.dirname, "build/wasm-complexity");
-    try {
-      const result = await cli(["build", "--no-check-deploy"], { cwd });
-      expect(result.exitCode).toBe(0);
-      expect(result.stderr).toMatch("Warning [MOPS-WASM-COMPLEXITY]");
-      expect(result.stdout).not.toMatch("check deploy canister");
-      expect(result.stdout).toMatch("Built 1 canister successfully");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--no-check-wasm leaves configured PocketIC validation enabled", async () => {
-    const cwd = path.join(import.meta.dirname, "build/wasm-complexity");
-    try {
-      const result = await cli(["build", "--no-check-wasm"], { cwd });
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).not.toMatch("MOPS-WASM-COMPLEXITY");
-      expect(result.stderr).toMatch("Error code: CanisterInvalidWasm");
-      expect(result.stdout).toMatch("check deploy canister main");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("[build].check-deploy installs the built Wasm on PocketIC", async () => {
-    const cwd = path.join(import.meta.dirname, "build/check-deploy-config");
-    try {
-      await cliSnapshot(["build"], { cwd }, 0);
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--check-deploy installs the built Wasm on PocketIC", async () => {
-    const cwd = path.join(import.meta.dirname, "build/check-deploy");
-    try {
-      await cliSnapshot(["build", "--check-deploy"], { cwd }, 0);
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--check-deploy accepts a path-pinned PocketIC binary", async () => {
-    const versionCwd = path.join(import.meta.dirname, "build/check-deploy");
-    const cwd = path.join(import.meta.dirname, "build/check-deploy-path");
-    const localBin = path.join(cwd, "pocket-ic");
-    try {
-      const binResult = await cli(["toolchain", "bin", "pocket-ic"], {
-        cwd: versionCwd,
-      });
-      expect(binResult.exitCode).toBe(0);
-      rmSync(localBin, { force: true });
-      linkSync(binResult.stdout.trim(), localBin);
-
-      const result = await cli(["build", "--check-deploy"], { cwd });
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toMatch("check deploy canister main");
-    } finally {
-      rmSync(localBin, { force: true });
-      cleanFixture(cwd);
-    }
-  });
-
-  test("build without check-deploy config does not check deployment", async () => {
-    const cwd = path.join(import.meta.dirname, "build/check-deploy");
-    try {
-      const result = await cli(["build"], { cwd });
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch("check deploy canister");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--no-check-deploy overrides [build].check-deploy", async () => {
-    const cwd = path.join(import.meta.dirname, "build/check-deploy-config");
-    try {
-      const result = await cli(["build", "--no-check-deploy"], { cwd });
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch("check deploy canister");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--check-deploy reports Wasm memory limit failures", async () => {
-    const cwd = path.join(import.meta.dirname, "build/check-deploy-fail");
-    try {
-      const result = await cli(["build", "--check-deploy"], { cwd });
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toMatch("PocketIC deployment check failed");
-      expect(result.stderr).toMatch("Wasm memory limit");
-      expect(result.stderr).toMatch(
-        "Error code: CanisterWasmMemoryLimitExceeded",
-      );
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--check-deploy reports Candid encoding errors without a deployment label", async () => {
-    const cwd = path.join(
-      import.meta.dirname,
-      "build/check-deploy-invalid-arg",
-    );
-    try {
-      const result = await cli(["build", "--check-deploy"], { cwd });
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toMatch("Invalid initArg for canister main");
-      expect(result.stderr).not.toMatch("PocketIC deployment check failed");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--check-deploy preserves an ordinary installation failure", async () => {
-    const cwd = path.join(import.meta.dirname, "build/check-deploy-trap");
-    try {
-      const result = await cli(["build", "--check-deploy"], { cwd });
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toMatch("PocketIC deployment check failed");
-      expect(result.stderr).toMatch("assertion failed");
-      expect(result.stderr).toMatch("Error code: CanisterCalledTrap");
-      expect(result.stderr).not.toMatch("MOPS-CHECK-DEPLOY-SKIPPED");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--check-deploy preserves PocketIC startup failures", async () => {
-    const cwd = path.join(
-      import.meta.dirname,
-      "build/check-deploy-startup-fail",
-    );
-    try {
-      const result = await cli(["build", "--check-deploy"], { cwd });
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toMatch("PocketIC deployment check failed");
-      expect(result.stdout).not.toMatch("check deploy canister");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("check-deploy skips chains incompatible with empty state and checks siblings", async () => {
-    const cwd = path.join(
-      import.meta.dirname,
-      "build/check-deploy-incomplete-migrations",
-    );
-    try {
-      const result = await cli(["build"], { cwd });
-      expect(result.exitCode).toBe(0);
-      expect(result.stderr).toMatch("Warning [MOPS-CHECK-DEPLOY-SKIPPED]");
-      expect(result.stderr).toMatch("Canister: problematic");
-      expect(result.stderr).toMatch("Canister: problematic2");
-      expect(
-        result.stderr.match(/Fresh PocketIC deployment check did not run\./g),
-      ).toHaveLength(2);
-      expect(result.stderr).toMatch(
-        "moc reported that the generated stable state is incompatible with an empty canister",
-      );
-      expect(result.stderr).toMatch("Compatibility error");
-      expect(result.stdout).not.toMatch("check deploy canister problematic");
-      expect(result.stdout).not.toMatch("check deploy canister problematic2");
-      expect(result.stdout).toMatch("check deploy canister healthy");
-      expect(result.stdout).toMatch("check deploy canister aliased");
-      expect(result.stdout).toMatch("Built 4 canisters successfully");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
+  // Lives here rather than in build-check-deploy because it builds
+  // `build/success`, and this file owns that fixture. Every test in it calls
+  // `cleanFixture`, which removes `.mops` — from a parallel worker that would
+  // delete a build another test is still using.
   test("--check-deploy works without a PocketIC pin (default version)", async () => {
     const cwd = path.join(import.meta.dirname, "build/success");
     try {
       const result = await cli(["build", "foo", "--check-deploy"], { cwd });
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toMatch("check deploy canister foo");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--check-deploy rejects a legacy PocketIC pin", async () => {
-    const cwd = path.join(import.meta.dirname, "build/check-deploy-legacy");
-    const result = await cli(["build", "--check-deploy"], { cwd });
-
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toMatch("pins below 9.0.0 no longer work");
-    expect(result.stdout).toMatch("mops toolchain use pocket-ic 14.0.0");
-  });
-
-  test("rejects an invalid wasmMemoryLimit without --check-deploy", async () => {
-    const cwd = path.join(import.meta.dirname, "build/invalid-memory-limit");
-    const result = await cli(["build"], { cwd });
-
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toMatch(
-      "Invalid wasmMemoryLimit for canister main: expected a positive integer number of bytes",
-    );
-    expect(result.stderr).not.toMatch("PocketIC deployment check failed");
-  });
-
-  test("[optimize] fails the build when wasm-opt errors", async () => {
-    const cwd = path.join(import.meta.dirname, "build/optimize-fail");
-    try {
-      const result = await cli(["build"], { cwd });
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toMatch(/Failed to optimize main\.wasm/);
-      expect(result.stderr).toMatch("mock-wasm-opt: intentional failure");
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("[optimize] without a wasm-opt pin errors instead of pinning one", async () => {
-    const cwd = path.join(import.meta.dirname, "build/optimize-unpinned");
-    const manifest = path.join(cwd, "mops.toml");
-    const before = readFileSync(manifest, "utf8");
-    try {
-      const result = await cli(["build"], { cwd });
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toMatch("wasm-opt is not pinned");
-      expect(result.stderr).toMatch("mops toolchain use wasm-opt 131");
-      // The build must not rewrite the manifest it was handed.
-      expect(readFileSync(manifest, "utf8")).toBe(before);
-      // ...and must fail before compiling anything.
-      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(false);
-    } finally {
-      cleanFixture(cwd);
-    }
-  });
-
-  test("--no-optimize builds despite an unpinned wasm-opt", async () => {
-    const cwd = path.join(import.meta.dirname, "build/optimize-unpinned");
-    try {
-      const result = await cli(["build", "--no-optimize"], { cwd });
-      expect(result.exitCode).toBe(0);
-      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(true);
     } finally {
       cleanFixture(cwd);
     }


### PR DESCRIPTION
`build.test.ts` took 203s of the CLI suite's 317s wall clock — on its own, the tail of the entire run. Jest parallelises across files rather than within one, so no worker count could shorten it: a 203s file is a 203s floor.

Split by concern into four files, none of them dominant:

| file | tests | covers |
|---|---|---|
| `build.test.ts` | 12 | core build behaviour, output paths, reproducibility, lock policy |
| `build-check-deploy.test.ts` | 11 | PocketIC deployment checks and their failure modes |
| `build-optimize.test.ts` | 5 | `[optimize]` / wasm-opt |
| `build-check-wasm.test.ts` | 5 | static Wasm analysis and memory limits |

Every test body moves verbatim. All 32 test names are byte-identical to before (`diff` of the sorted name sets is empty), and all 10 snapshots still pass — the only snapshot change is the two keys that pick up the new `build check-deploy` describe prefix, moved into their own `.snap` file.

## The one thing that is not a pure move

Fixture ownership has to stay a clean partition, because the split changes how these tests run against each other. Every test here calls `cleanFixture`, which does `rm -rf` on the fixture's `.mops` — harmless when all 32 tests shared one file and ran serially, but files run in *parallel workers*.

`build/success` was the only fixture that would have ended up referenced from two files, so `--check-deploy works without a PocketIC pin (default version)` stays in `build.test.ts` with the rest of `build/success` instead of moving to `build-check-deploy` where it thematically belongs. A comment at the test says why. Every other fixture is touched by exactly one file:

```
build.test.ts              build/custom-output  build/error  build/success
build-optimize.test.ts     build/optimize  build/optimize-fail  build/optimize-unpinned
build-check-wasm.test.ts   build/check-wasm-flag  build/invalid-memory-limit  build/wasm-complexity
build-check-deploy.test.ts build/check-deploy*  (nine fixtures, all exclusive)
```

`cleanFixture` moves to a small `build-helpers.ts` shared by the four; it was previously local to `build.test.ts` and is not duplicated anywhere else in the suite.

## What is unchanged

No test gains, loses or alters an assertion, and no fixture changes. Locally the four suites pass together in 150s: `4 passed`, `32 passed`, `Snapshots: 10 passed`, no obsolete snapshots reported.

This does not by itself make CI faster — with three jest workers the suite is bounded by total work, not by the tail. It removes the obstacle to sharding the suite across jobs, which is the follow-up.