### PR TITLE
ci: shard the CLI tests across three jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,15 @@ jobs:
   cli-tests:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    name: cli tests
+    name: cli tests (${{ matrix.shard }}/3)
+    # Three shards, because the `sites` job is the floor: splitting further
+    # spends runner minutes without moving the workflow's wall clock. Jest
+    # shards by test path rather than by recorded timing, so the split is
+    # approximate — the point is to stop one suite being the whole tail.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -154,6 +162,10 @@ jobs:
       # parallel workers don't race on the same downloads.
       # When adding a new fixture with [toolchain] or [dependencies],
       # add the corresponding download/install command below.
+      #
+      # Every shard installs every fixture, not just the ones its own slice
+      # needs. That is deliberate: all three share one cache key, so whichever
+      # shard wins the save race has to publish a complete cache.
       - name: Pre-cache moc 1.3.0 and test fixture dependencies
         run: |
           mops toolchain use moc 1.3.0 && mops toolchain use moc ${{ env.MOC_VERSION }}
@@ -172,7 +184,7 @@ jobs:
       - name: Run CLI tests
         env:
           MOPS_TEST_GLOBAL: 1
-        run: cd cli && npm test
+        run: cd cli && npm test -- --shard=${{ matrix.shard }}/3
 
   bundle-smoke-test:
     timeout-minutes: 20


### PR DESCRIPTION
The test step is the last thing left on the CLI job's critical path, and it is CPU-saturated rather than idle. Jest reports 899 CPU-seconds of work — `moc` compiles, `wasm-opt` runs, PocketIC replica starts — completing in ~320s wall clock. That is 2.8x parallelism: three workers on a 4-vCPU runner, all pegged. Nothing is waiting on the network, so the only lever left is more machines.

## Before / after

```
before  cli tests           test step ~360s
after   cli tests (1/3)     ─┐
        cli tests (2/3)      ├ ~140s each
        cli tests (3/3)     ─┘
```

Verified locally that the flag reaches jest through `npm test --` and splits the 45 suites evenly:

```
shard 1: 15 suites
shard 2: 15 suites
shard 3: 15 suites
```

## Why three and not six

The `sites` job is the workflow's floor at ~6 minutes. A fourth shard would burn runner minutes without moving the wall clock, so three is where the returns stop.

## On the balance

Jest shards by test path, not by recorded timing, so the split is approximate and shifts whenever a test file is added or renamed. With [#731](https://github.com/caffeinelabs/mops/pull/731) now merged the four heavy suites spread across all three shards, and the binding constraint is no longer one dominant file:

```
shard 1  build.test.ts, build-optimize.test.ts, check.test.ts
shard 2  cli.test.ts, check-fix.test.ts, check-stable.test.ts
shard 3  locked.test.ts, build-check-deploy.test.ts, build-check-wasm.test.ts
```

Since jest cannot split a single file, each shard is floored by its largest suite. That floor used to be `build.test.ts` at 203s; it is now `locked.test.ts` at 137s, which is what makes three shards land at roughly equal wall clock instead of one carrying the tail.

## Follow-up worth flagging

Once this lands, `sites` becomes the critical path, and its ~6 minutes is mostly a full `ci:postinstall` plus four sequential Docusaurus/Vite builds. Splitting or parallelising those is the next thing to look at, and is not attempted here.