### PR TITLE
fix(cli): mops outdated exit codes, and report GitHub deps

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -219,7 +219,8 @@ mops remove base
 ### Dependency Management
 
 ```bash
-mops outdated             # list outdated dependencies (caret-bound)
+mops outdated             # list outdated deps (caret-bound); exit 1 if any, 2 if the check failed
+mops outdated core        # check a single package
 mops update               # update all within caret bound (no major-version crossing)
 mops update core          # update specific package within caret bound
 mops update --major       # allow updates that cross major versions

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Together those remove roughly 1.5 s of fixed cost from a warm-cache `mops install && mops update` in a fresh directory, none of it dependent on how many packages a project has.
 - File metadata and the first chunk of each file are now fetched concurrently rather than chained, halving per-file round trips for the single-chunk case that covers essentially every Motoko source file.
 - Chunk concatenation is no longer quadratic. **Breaking for programmatic consumers of the `ic-mops` package**: `downloadFile` and `downloadPackageFiles` now return `Uint8Array` instead of `Array<number>`.
+- `mops outdated` and `mops update` no longer make a registry call when a project has no registry dependencies to check.
 
 ### Integrity
 
@@ -26,6 +27,8 @@
 
 - **A local `path` dependency's own `mops.toml` no longer goes unnoticed.** Adding or bumping a dependency inside a local package left `mops.lock` judged fresh, so `mops install` exited 0, installed nothing, and never passed the new dependency to the compiler — the package then failed to build against a dependency mops had reported as installed. `mops.lock` now records a hash of the `[dependencies]` of every path dependency it reaches, transitively, so editing any of them makes the lockfile stale.
 - **Changing `MOPS_ENV` no longer leaves `mops.lock` pinned to the previous environment.** `{MOPS_ENV}` paths are stored expanded in the lockfile, but the freshness check compared the unexpanded string, so a full `mops install` under a new environment exited 0 and kept building against the old environment's directories. `mops install` now re-resolves, `mops sources` reports the current environment, and `mops install --locked` fails rather than silently using the wrong paths. Note that a committed lockfile now only satisfies `--locked` for the `MOPS_ENV` it was generated under.
+- **`mops outdated` is now usable as a CI gate.** It exited `0` whether or not anything was outdated. It now exits `1` when updates are available and `2` when the check itself could not be completed (no `mops.toml`, unknown package, registry or GitHub lookup error), so a partial report can never be mistaken for a clean bill of health. `1` for "found something" matches `npm outdated` and `pnpm outdated`.
+- **`mops outdated` and `mops update` no longer disagree.** `outdated` skipped GitHub dependencies while `mops update` updates them, so it could print "All dependencies are up to date!" for a project where `mops update` would rewrite a GitHub pin. GitHub dependencies whose branch has moved past the pinned commit are now reported, using the same rule `mops update` applies.
 - **`mops sync` no longer destroys a pinned alias dependency.** Given `map = "9.0.1"` and `"map@8.1.0" = "8.1.0"`, sync compared imports (`map@8.1.0`) against alias-stripped manifest keys (`map`), so it reported the alias as both missing and unused — adding it overwrote `map` with `8.1.0`, and a single run could remove the dependency entirely. Aliases are now matched verbatim and added under their own key.
 - `mops sync` adds packages imported only from `test`, `tests`, `bench` or `benchmark` directories to `[dev-dependencies]` rather than `[dependencies]`. Already-declared packages are never moved between sections.
 - `mops sync` removes an unused package from **both** sections when it is declared in both; previously it was only removed from `[dependencies]`, leaving a dangling entry that the next run reported again.
@@ -36,6 +39,7 @@
 
 ### Added
 
+- `mops outdated [pkg]` accepts a package name, matching `mops update [pkg]`.
 - `mops sync --dry-run` prints what would be added and removed without touching `mops.toml`, the local cache or `mops.lock`.
 - `mops cache clean --global` cleans only the global cache and keeps the project's `.mops` directory.
 - `mops.lock` gains an optional `localDepsHash` field, written only for projects that declare a local `path` dependency. Those projects have their lockfile regenerated once on the next `mops install`, and `mops install --locked` fails until the regenerated lockfile is committed. Projects without path dependencies are unaffected — the field is omitted entirely and existing lockfiles stay valid.

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -813,7 +813,7 @@ program
 
 // outdated
 program
-  .command("outdated")
+  .command("outdated [pkg]")
   .description(
     "Print outdated dependencies in mops.toml within the caret bound (does not cross major versions, or pre-1.0 minor versions)",
   )
@@ -829,8 +829,16 @@ program
       "Restrict updates to patch versions only (e.g. 1.2.3 -> 1.2.4, never 1.2.3 -> 1.3.0)",
     ),
   )
-  .action(async (options) => {
-    await outdated(options);
+  .addHelpText(
+    "after",
+    "\nGitHub dependencies are checked against their branch head (one GitHub API call each).\n" +
+      "\nExit codes:\n" +
+      "  0  everything is up to date\n" +
+      "  1  updates are available\n" +
+      "  2  the check failed (no mops.toml, unknown [pkg], registry or GitHub lookup error)",
+  )
+  .action(async (pkg, options) => {
+    await outdated(pkg, options);
   });
 
 // update

--- a/cli/commands/available-updates.ts
+++ b/cli/commands/available-updates.ts
@@ -2,17 +2,25 @@ import process from "node:process";
 import chalk from "chalk";
 import semver from "semver";
 import { mainActor } from "../api/actors.js";
+import { getGithubCommit, parseGithubURL } from "../mops.js";
 import { Config } from "../types.js";
 import { getDepName, getDepPinnedVersion } from "../helpers/get-dep-name.js";
 import { SemverPart } from "../declarations/main/main.did.js";
 
 export type UpdateBound = "patch" | "caret" | "major";
 
+export type AvailableUpdatesOptions = {
+  // `mops outdated` reports registry failures itself, so it can exit with its own
+  // "lookup failed" code instead of the shared exit(1).
+  throwOnError?: boolean;
+};
+
 // [pkg, oldVersion, newVersion]
 export async function getAvailableUpdates(
   config: Config,
   pkg?: string,
   bound: UpdateBound = "caret",
+  { throwOnError }: AvailableUpdatesOptions = {},
 ): Promise<Array<[string, string, string]>> {
   let deps = Object.values(config.dependencies || {});
   let devDeps = Object.values(config["dev-dependencies"] || {});
@@ -25,6 +33,11 @@ export async function getAvailableUpdates(
       getDepName(dep.name) === dep.name ||
       getDepPinnedVersion(dep.name).split(".").length !== 3,
   );
+
+  // Nothing to resolve: skip the registry round-trip entirely.
+  if (depsToUpdate.length === 0) {
+    return [];
+  }
 
   let getCurrentVersion = (pkg: string, updateVersion: string) => {
     for (let dep of allDeps) {
@@ -62,6 +75,9 @@ export async function getAvailableUpdates(
   );
 
   if ("err" in res) {
+    if (throwOnError) {
+      throw new Error(res.err);
+    }
     console.log(chalk.red("Error:"), res.err);
     process.exit(1);
   }
@@ -69,4 +85,72 @@ export async function getAvailableUpdates(
   return res.ok
     .filter((dep) => dep[1] !== getCurrentVersion(dep[0], dep[1]))
     .map((dep) => [dep[0], getCurrentVersion(dep[0], dep[1]), dep[1]]);
+}
+
+export type GithubUpdate = {
+  name: string;
+  repo: string; // "org/name"
+  branch: string;
+  current: string; // pinned commit hash, empty when mops.toml pins only a branch
+  latest: string;
+};
+
+export type GithubUpdateError = {
+  name: string;
+  message: string;
+};
+
+export type GithubUpdates = {
+  updates: GithubUpdate[];
+  errors: GithubUpdateError[];
+};
+
+// `mops update` re-resolves GitHub branches, so anything reporting available updates
+// must check them too or it would call a dep up to date that `update` would move.
+export async function getAvailableGithubUpdates(
+  config: Config,
+  pkg?: string,
+): Promise<GithubUpdates> {
+  let deps = Object.values(config.dependencies || {});
+  let devDeps = Object.values(config["dev-dependencies"] || {});
+  let githubDeps = [...deps, ...devDeps].filter((dep) => dep.repo);
+  if (pkg) {
+    githubDeps = githubDeps.filter((dep) => dep.name === pkg);
+  }
+
+  // One unauthenticated GitHub API call per repo dep (60/h/IP), so run them
+  // concurrently and only for deps actually declared by repo.
+  let results = await Promise.all(
+    githubDeps.map(
+      async (dep): Promise<GithubUpdate | GithubUpdateError | undefined> => {
+        let { org, gitName, branch, commitHash } = parseGithubURL(
+          dep.repo || "",
+        );
+        try {
+          let commit = await getGithubCommit(`${org}/${gitName}`, branch);
+          if (commit.sha === commitHash) {
+            return undefined;
+          }
+          return {
+            name: dep.name,
+            repo: `${org}/${gitName}`,
+            branch,
+            current: commitHash,
+            latest: commit.sha,
+          };
+        } catch (err: any) {
+          return { name: dep.name, message: err.message };
+        }
+      },
+    ),
+  );
+
+  return {
+    updates: results.filter(
+      (res): res is GithubUpdate => !!res && "latest" in res,
+    ),
+    errors: results.filter(
+      (res): res is GithubUpdateError => !!res && "message" in res,
+    ),
+  };
 }

--- a/cli/commands/outdated.ts
+++ b/cli/commands/outdated.ts
@@ -1,25 +1,64 @@
+import process from "node:process";
 import chalk from "chalk";
 import { checkConfigFile, readConfig } from "../mops.js";
-import { getAvailableUpdates } from "./available-updates.js";
+import {
+  GithubUpdates,
+  UpdateBound,
+  getAvailableGithubUpdates,
+  getAvailableUpdates,
+} from "./available-updates.js";
 import { getDepName, getDepPinnedVersion } from "../helpers/get-dep-name.js";
 
-export async function outdated({
-  major,
-  patch,
-}: { major?: boolean; patch?: boolean } = {}) {
+// grep/diff convention: 1 = "found something", 2 = "failed to look". A CI gate can
+// fail on any non-zero code and still tell a stale dependency from a broken lookup.
+const EXIT_OUTDATED = 1;
+const EXIT_ERROR = 2;
+
+export async function outdated(
+  pkg?: string,
+  { major, patch }: { major?: boolean; patch?: boolean } = {},
+) {
   if (!checkConfigFile()) {
+    process.exitCode = EXIT_ERROR;
     return;
   }
   let config = readConfig();
 
-  let available = await getAvailableUpdates(
-    config,
-    undefined,
-    major ? "major" : patch ? "patch" : "caret",
-  );
+  if (
+    pkg &&
+    !config.dependencies?.[pkg] &&
+    !config["dev-dependencies"]?.[pkg]
+  ) {
+    console.log(chalk.red(`Package "${pkg}" is not installed!`));
+    process.exitCode = EXIT_ERROR;
+    return;
+  }
 
-  if (available.length === 0) {
-    console.log(chalk.green("All dependencies are up to date!"));
+  let bound: UpdateBound = major ? "major" : patch ? "patch" : "caret";
+  let available: Array<[string, string, string]>;
+  let github: GithubUpdates;
+
+  try {
+    [available, github] = await Promise.all([
+      getAvailableUpdates(config, pkg, bound, { throwOnError: true }),
+      getAvailableGithubUpdates(config, pkg),
+    ]);
+  } catch (err: any) {
+    console.log(chalk.red("Error:"), err.message || err);
+    process.exitCode = EXIT_ERROR;
+    return;
+  }
+
+  if (available.length === 0 && github.updates.length === 0) {
+    if (github.errors.length === 0) {
+      console.log(
+        chalk.green(
+          pkg
+            ? `Package "${pkg}" is up to date!`
+            : "All dependencies are up to date!",
+        ),
+      );
+    }
   } else {
     console.log("Available updates:");
     let allDeps = [
@@ -38,5 +77,25 @@ export async function outdated({
 
       console.log(`${name} ${chalk.yellow(dep[1])} -> ${chalk.green(dep[2])}`);
     }
+    for (let dep of github.updates) {
+      let current = dep.current ? dep.current.slice(0, 7) : "unpinned";
+      console.log(
+        `${dep.name} ${chalk.yellow(current)} -> ${chalk.green(dep.latest.slice(0, 7))} ` +
+          chalk.dim(`(github: ${dep.repo}#${dep.branch})`),
+      );
+    }
+  }
+
+  for (let err of github.errors) {
+    console.log(
+      chalk.red("Error: ") + `Failed to check ${err.name}: ${err.message}`,
+    );
+  }
+
+  // An incomplete report must not pass for a clean bill of health.
+  if (github.errors.length) {
+    process.exitCode = EXIT_ERROR;
+  } else if (available.length || github.updates.length) {
+    process.exitCode = EXIT_OUTDATED;
   }
 }

--- a/cli/tests/outdated.test.ts
+++ b/cli/tests/outdated.test.ts
@@ -1,0 +1,264 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const getHighestSemverBatch = jest.fn<(...args: any[]) => Promise<any>>();
+
+// `api/actors` pulls in the generated `*.did.js` declarations, which the ESM
+// `.js` -> extensionless moduleNameMapper resolves to the raw `.did` files.
+jest.unstable_mockModule("../api/actors.js", () => ({
+  mainActor: jest.fn(async () => ({ getHighestSemverBatch })),
+  mainOnewayCall: jest.fn(),
+  storageActor: jest.fn(),
+}));
+
+const { outdated } = await import("../commands/outdated.js");
+
+const SHA_OLD = "1111111111111111111111111111111111111111";
+const SHA_NEW = "2222222222222222222222222222222222222222";
+
+let originalCwd = process.cwd();
+let originalFetch = globalThis.fetch;
+let logs: string[] = [];
+let logSpy: ReturnType<typeof jest.spyOn>;
+
+const makeProject = (toml: string) => {
+  let root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "mops-outdated-")),
+  );
+  fs.writeFileSync(path.join(root, "mops.toml"), toml);
+  process.chdir(root);
+  return root;
+};
+
+// Stub the GitHub commits API so no test depends on the network or the
+// unauthenticated rate limit.
+const stubGithub = (sha: string) => {
+  globalThis.fetch = jest.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ sha }),
+  })) as unknown as typeof fetch;
+};
+
+const failGithub = (message: string) => {
+  globalThis.fetch = jest.fn(async () => {
+    throw new Error(message);
+  }) as unknown as typeof fetch;
+};
+
+const output = () =>
+  logs.join("\n").replace(new RegExp(`\\[[0-9;]*m`, "g"), "");
+
+beforeEach(() => {
+  logs = [];
+  logSpy = jest.spyOn(console, "log").mockImplementation((...args: any[]) => {
+    logs.push(args.join(" "));
+  });
+  getHighestSemverBatch.mockReset();
+  process.exitCode = 0;
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  globalThis.fetch = originalFetch;
+  process.chdir(originalCwd);
+  process.exitCode = 0;
+});
+
+describe("mops outdated exit codes", () => {
+  test("exits 0 when everything is up to date", async () => {
+    makeProject('[dependencies]\ncore = "1.0.0"\n');
+    getHighestSemverBatch.mockResolvedValue({ ok: [["core", "1.0.0"]] });
+
+    await outdated();
+
+    expect(output()).toMatch("All dependencies are up to date!");
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("exits 1 when a mops dependency is outdated", async () => {
+    makeProject('[dependencies]\ncore = "1.0.0"\n');
+    getHighestSemverBatch.mockResolvedValue({ ok: [["core", "1.2.0"]] });
+
+    await outdated();
+
+    expect(output()).toMatch("core 1.0.0 -> 1.2.0");
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("exits 1 for an outdated dev-dependency", async () => {
+    makeProject('[dev-dependencies]\ntest = "1.0.0"\n');
+    getHighestSemverBatch.mockResolvedValue({ ok: [["test", "1.1.0"]] });
+
+    await outdated();
+
+    expect(output()).toMatch("test 1.0.0 -> 1.1.0");
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("exits 2 on a registry error, without claiming anything is up to date", async () => {
+    makeProject('[dependencies]\ncore = "1.0.0"\n');
+    getHighestSemverBatch.mockResolvedValue({ err: "Package not found" });
+
+    await outdated();
+
+    expect(output()).toMatch("Package not found");
+    expect(output()).not.toMatch("up to date");
+    expect(process.exitCode).toBe(2);
+  });
+
+  test("exits 2 when the registry call fails", async () => {
+    makeProject('[dependencies]\ncore = "1.0.0"\n');
+    getHighestSemverBatch.mockRejectedValue(new Error("fetch failed"));
+
+    await outdated();
+
+    expect(output()).toMatch("fetch failed");
+    expect(output()).not.toMatch("up to date");
+    expect(process.exitCode).toBe(2);
+  });
+
+  test("exits 2 when mops.toml is missing", async () => {
+    let root = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "mops-outdated-empty-")),
+    );
+    process.chdir(root);
+
+    await outdated();
+
+    expect(output()).toMatch("mops.toml' not found");
+    expect(process.exitCode).toBe(2);
+  });
+
+  test("does not call the registry when there is nothing to check", async () => {
+    makeProject('[package]\nname = "test"\n');
+
+    await outdated();
+
+    expect(getHighestSemverBatch).not.toHaveBeenCalled();
+    expect(output()).toMatch("All dependencies are up to date!");
+    expect(process.exitCode).toBe(0);
+  });
+});
+
+// `mops update` re-resolves GitHub branches, so `mops outdated` must report them
+// or it would print "up to date" for a dep that `update` would move.
+describe("mops outdated github dependencies", () => {
+  const githubToml = (sha: string) =>
+    `[dependencies]\nmydep = "https://github.com/org/repo#main@${sha}"\n`;
+
+  test("reports a GitHub dep whose branch moved and exits 1", async () => {
+    makeProject(githubToml(SHA_OLD));
+    stubGithub(SHA_NEW);
+
+    await outdated();
+
+    expect(output()).toMatch(
+      "mydep 1111111 -> 2222222 (github: org/repo#main)",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("exits 0 when the pinned commit is the branch head", async () => {
+    makeProject(githubToml(SHA_OLD));
+    stubGithub(SHA_OLD);
+
+    await outdated();
+
+    expect(output()).toMatch("All dependencies are up to date!");
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("reports a branch pinned without a commit as unpinned", async () => {
+    makeProject('[dependencies]\nmydep = "https://github.com/org/repo#main"\n');
+    stubGithub(SHA_NEW);
+
+    await outdated();
+
+    expect(output()).toMatch("mydep unpinned -> 2222222");
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("exits 2 when a GitHub lookup fails", async () => {
+    makeProject(githubToml(SHA_OLD));
+    failGithub("API rate limit exceeded");
+
+    await outdated();
+
+    expect(output()).toMatch("Failed to check mydep: API rate limit exceeded");
+    expect(output()).not.toMatch("up to date");
+    expect(process.exitCode).toBe(2);
+  });
+
+  test("a failed GitHub lookup outranks found mops updates", async () => {
+    makeProject(
+      `[dependencies]\ncore = "1.0.0"\nmydep = "https://github.com/org/repo#main@${SHA_OLD}"\n`,
+    );
+    getHighestSemverBatch.mockResolvedValue({ ok: [["core", "1.2.0"]] });
+    failGithub("API rate limit exceeded");
+
+    await outdated();
+
+    expect(output()).toMatch("core 1.0.0 -> 1.2.0");
+    expect(process.exitCode).toBe(2);
+  });
+});
+
+describe("mops outdated [pkg]", () => {
+  test("reports only the requested package", async () => {
+    makeProject('[dependencies]\ncore = "1.0.0"\nmap = "1.0.0"\n');
+    getHighestSemverBatch.mockResolvedValue({ ok: [["core", "1.2.0"]] });
+
+    await outdated("core");
+
+    expect(getHighestSemverBatch).toHaveBeenCalledWith([
+      ["core", "1.0.0", { minor: null }],
+    ]);
+    expect(output()).toMatch("core 1.0.0 -> 1.2.0");
+    expect(output()).not.toMatch("map");
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("exits 0 when the requested package is up to date", async () => {
+    makeProject('[dependencies]\ncore = "1.0.0"\nmap = "1.0.0"\n');
+    getHighestSemverBatch.mockResolvedValue({ ok: [["core", "1.0.0"]] });
+
+    await outdated("core");
+
+    expect(output()).toMatch('Package "core" is up to date!');
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("checks only the requested GitHub dep", async () => {
+    makeProject(
+      `[dependencies]\nmydep = "https://github.com/org/repo#main@${SHA_OLD}"\nother = "https://github.com/org/other#main@${SHA_OLD}"\n`,
+    );
+    stubGithub(SHA_NEW);
+
+    await outdated("mydep");
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(output()).toMatch("mydep 1111111 -> 2222222");
+    expect(output()).not.toMatch("other");
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("exits 2 for a package that is not a dependency", async () => {
+    makeProject('[dependencies]\ncore = "1.0.0"\n');
+
+    await outdated("nope");
+
+    expect(output()).toMatch('Package "nope" is not installed!');
+    expect(getHighestSemverBatch).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(2);
+  });
+});

--- a/docs/docs/cli/1-deps/03-mops-outdated.md
+++ b/docs/docs/cli/1-deps/03-mops-outdated.md
@@ -10,6 +10,41 @@ Print available dependency updates within the caret bound (does not cross major 
 mops outdated
 ```
 
+Check only a specific dependency
+```
+mops outdated [pkg]
+```
+
+Nothing is written — `mops.toml` and the [lockfile](../../10-mops.lock.md) are left untouched. Use [`mops update`](./04-mops-update.md) to apply the updates it reports.
+
+```bash
+$ mops outdated
+Available updates:
+core 1.0.0 -> 1.2.0
+mydep 1111111 -> 06d7c77 (github: org/repo#master)
+```
+
+## Reported dependencies
+
+`mops outdated` reports exactly what [`mops update`](./04-mops-update.md) would change:
+
+- **registry packages** — the highest version within the bound (see [`--major`](#--major) / [`--patch`](#--patch))
+- **GitHub packages** — the branch head, when it differs from the commit pinned in `mops.toml`. Old and new commits are shown abbreviated; a dependency that pins a branch without a commit is shown as `unpinned`. Each GitHub dependency costs one call to the unauthenticated GitHub API, which is [rate-limited to 60 requests per hour per IP](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api).
+
+Hard-pinned registry packages (e.g. `"core@1.2.3" = "1.2.3"`) and local `path` dependencies are never reported — `mops update` does not move them either.
+
+## Exit codes
+
+Suitable as a CI gate: a stale dependency is distinguishable from a failed lookup.
+
+| Code | Meaning |
+|---|---|
+| `0` | Everything is up to date |
+| `1` | Updates are available |
+| `2` | The check could not be completed — no `mops.toml`, unknown `[pkg]`, or a registry / GitHub lookup that failed |
+
+Code `2` wins over `1`: if any lookup fails, the report is incomplete, so it is never reported as `0` or as a plain "outdated".
+
 ## Options
 
 ### `--major`


### PR DESCRIPTION
`mops outdated` exited `0` whether or not anything was outdated, so it could not gate CI. `pnpm outdated` exits 1; `cargo outdated` has `--exit-code`.

```
$ mops outdated
base 0.14.5 -> 0.14.14
Before: $? = 0
After:  $? = 1
```

Exit codes are now `0` up to date, `1` updates available, `2` the check could not be completed — missing `mops.toml`, unknown `[pkg]`, or a registry/GitHub lookup failure. `2` wins when both apply, because a partial report must never read as a clean bill of health, and a failed lookup must never read as "outdated". `1` for "found something" and `2` for "failed to look" follows the grep/diff convention and matches `npm outdated`.

## The exit code was only half the problem

`getAvailableUpdates` filtered to dependencies with a truthy `version`, which silently excludes GitHub (`repo`) dependencies — but `mops update` **does** update them, by re-resolving the branch head and rewriting the pin. So the two commands disagreed about what "outdated" means:

```
# mops.toml:  mydep = "https://github.com/org/repo#master@1111111"
#             (branch has since moved to 06d7c77)

$ mops outdated
Before: All dependencies are up to date!     # then `mops update` rewrites the pin
After:  mydep 1111111 -> 06d7c77 (github: org/repo#master)
```

That's the defect that made the exit code useless: a green `mops outdated` didn't mean a subsequent `mops update` would be a no-op. Both commands now apply the same rule — same helper shape, same `[pkg]` filter, same "sha differs from branch head" comparison — so they can't drift apart again.

A GitHub lookup that fails (rate limit, network) reports per-dependency and exits `2`. It never degrades to a silent "up to date".

## Cost

One GitHub API call per `repo` dependency, and most projects have none. They're issued concurrently, unlike `mops update`'s serial loop. Against that, the registry round trip is now skipped entirely when a project has no registry dependencies, so a GitHub-only project makes strictly fewer calls than before.

No auth-token support and no `--no-github` escape hatch: neither npm nor cargo has an analogue, and inventing one before anyone hits the unauthenticated 60 req/h limit seemed premature.

## What is unchanged

`mops update`'s behaviour is byte-for-byte identical. `getAvailableUpdates` gained a fourth optional argument for opting into throwing instead of `process.exit(1)`, and only `outdated` passes it, so `update` keeps its existing print-and-exit path.

`getHighestSemverBatch`'s `assert(list.size() < 100)` is untouched and unaffected — `repo` deps were never in that batch, and passing `[pkg]` only shrinks it. It remains a live trap for projects with 100+ direct dependencies, tracked as item 26 in [#723](https://github.com/caffeinelabs/mops/issues/723).

## Follow-up worth flagging

`mops update <not-installed-pkg>` still exits `0` while `mops outdated <not-installed-pkg>` now exits `2`. Worth aligning `update` to `2`. And `mops update` still has its own inline GitHub resolution loop that duplicates the rule this PR extracted into a helper — a clean refactor now that the helper exists, but out of scope here since it would put `update.ts` in the diff.

Part of the GA follow-up work from the Cargo/pnpm audit ([#723](https://github.com/caffeinelabs/mops/issues/723), item 17), which the triage there marks as pre-GA because exit codes are a contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
