### PR TITLE
test(cli): stop jest resolving .did.js to the Candid file

### DIFF
--- a/cli/jest.config.js
+++ b/cli/jest.config.js
@@ -10,6 +10,10 @@ export default {
   // Source files import each other with .js suffixes (ESM), which jest cannot
   // resolve back to the .ts sources without this mapping.
   moduleNameMapper: {
+    // The generated declarations are real .js next to a .did of the same name,
+    // so stripping the suffix hands jest the Candid file to parse as JavaScript.
+    // Must precede the general rule — jest takes the first pattern that matches.
+    "^(\\.{1,2}/.*\\.did)\\.js$": "$1.js",
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
   transform: {

--- a/cli/tests/add-remove-ergonomics.test.ts
+++ b/cli/tests/add-remove-ergonomics.test.ts
@@ -17,6 +17,50 @@ describe("add/remove ergonomics", () => {
   const toml = (cwd: string) =>
     readFileSync(path.join(cwd, "mops.toml"), "utf8");
 
+  // Moving between sections and searching both are interactive-only: `mops
+  // update` and `mops sync` call these for a package they already located in a
+  // specific section. Applying either there would drop the other entry (update)
+  // or error on the second of a paired call (sync). These call the functions
+  // directly because the CLI always opts in, so a CLI-level test cannot see the
+  // default.
+  describe("programmatic callers keep per-section semantics", () => {
+    const inDir = async <T>(cwd: string, fn: () => Promise<T>) => {
+      const before = process.cwd();
+      process.chdir(cwd);
+      try {
+        return await fn();
+      } finally {
+        process.chdir(before);
+      }
+    };
+
+    test("add() without moveSections leaves the other section alone", async () => {
+      const cwd = await makeTempFixture("local-both");
+      const { add } = await import("../commands/add.js");
+
+      await inDir(cwd, () =>
+        add("./packages/one", { dev: true, lock: "skip" }),
+      );
+
+      // both declarations survive — this is what `mops update` relies on
+      expect(toml(cwd)).toBe(
+        '[dependencies]\none = "./packages/one"\n\n[dev-dependencies]\none = "./packages/one"\n',
+      );
+    });
+
+    test("remove() without anySection touches only [dependencies]", async () => {
+      const cwd = await makeTempFixture("local-both");
+      const { remove } = await import("../commands/remove.js");
+
+      await inDir(cwd, () => remove("one", { lock: "skip" }));
+
+      // the dev entry is left for sync's second, --dev call to remove
+      expect(toml(cwd)).toBe(
+        '[dependencies]\n[dev-dependencies]\none = "./packages/one"\n',
+      );
+    });
+  });
+
   describe("add moves an entry between sections", () => {
     test("--dev moves a dependency to [dev-dependencies]", async () => {
       const cwd = await makeTempFixture("local-prod");


### PR DESCRIPTION
`moduleNameMapper` rewrote `^(\.{1,2}/.*)\.js$` → `$1`, so ESM's `.js` import specifiers resolve back to their `.ts` sources. But the generated declarations are *real* `.js` files sitting next to a `.did` of the same name, so that rule stripped the suffix off `../declarations/main/main.did.js` and handed jest the **Candid** file to parse as JavaScript:

```
Details:
  cli/declarations/main/main.did:1
  type User =
       ^^^^
  SyntaxError: Unexpected identifier 'User'
```

Anything that transitively imports the declarations — which is every command module — was therefore unimportable from a test. That is not hypothetical: [#726](https://github.com/caffeinelabs/mops/pull/726) worked around it by shelling out to a subprocess probe, and [#736](https://github.com/caffeinelabs/mops/pull/736) wrote two regression tests, hit this, and deleted them.

The fix is one more specific rule ahead of the general one, since jest uses the first pattern that matches.

## The tests #736 had to drop

Landing them here is also the proof the mapper change works — they fail with the `SyntaxError` without it.

They pin behaviour a CLI-level test structurally cannot reach. `mops add` and `mops remove` always opt into moving an entry between sections and searching both, so only a direct call can observe the default — and the default is what `mops update` and `mops sync` depend on:

- `add()` without `moveSections` must leave the other section alone, or `mops update` silently deletes a production entry for a package declared in both sections.
- `remove()` without `anySection` must touch only `[dependencies]`, or `mops sync` clears both on the first of its paired per-section calls and prints `No dev dependency to remove` on the second.

Both regressions were real and caught by review on #736; until now the only thing preventing their return was the code comment.

## Verification

`add-remove-ergonomics` 15/15, plus `locked`, `resolve`, `outdated` and `sync-plan` — 65 passing, no change in behaviour from the mapper edit.

One suite, `github-dep-lock.test.ts`, is failing in my local environment. It is **not** related: I confirmed it fails identically with `v3`'s unmodified `jest.config.js`, and it passed in CI on #737. It downloads real archives from GitHub and I had been repeatedly clearing and repopulating that cache while debugging the hash-determinism bug, so I expect it to be local state. Worth a glance if CI disagrees.

Item 32 in [#723](https://github.com/caffeinelabs/mops/issues/723).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
