### PR TITLE
fix(cli): stop a local path dependency cycle overflowing the stack

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- `mops install` no longer crashes with a raw `RangeError: Maximum call stack size exceeded` when two local `path` dependencies require each other, or when one requires itself. The install walk now skips a local package it has already visited in the same run, naming neither a cycle nor an error — the packages install normally.
+
 - Fixed `mops remove <pkg>` crashing with `Invalid dependency value ""` when the dependency is a local path dep.
 - `mops remove` now echoes the dependency value it removed for GitHub and local path deps, instead of an empty version.
 - Temporary compatibility shim: `mops add`, `remove`, `install`, `sync` and `update` again accept the removed 2.x flag `--lock <check|update|ignore>` instead of failing to parse. The value is ignored — including `check`, which is **not** treated as `--locked` — so v2 call sites keep working during the 3.x rollout. Migrate to `mops install --locked` for CI enforcement; the flag will be removed.

--- a/cli/commands/install/install-dep.ts
+++ b/cli/commands/install/install-dep.ts
@@ -18,6 +18,7 @@ export async function installDep(
   dep: Dependency,
   { verbose, silent, threads, ignoreTransitive }: InstallDepOptions = {},
   parentPkgPath?: string,
+  visitedLocalDeps?: Set<string>,
 ): Promise<boolean> {
   if (dep.repo) {
     return installFromGithub(dep.name, dep.repo, {
@@ -30,11 +31,16 @@ export async function installDep(
     if (parentPkgPath) {
       depPath = path.resolve(parentPkgPath, dep.path);
     }
-    return installLocalDep(dep.name, depPath, {
-      silent,
-      verbose,
-      ignoreTransitive,
-    });
+    return installLocalDep(
+      dep.name,
+      depPath,
+      {
+        silent,
+        verbose,
+        ignoreTransitive,
+      },
+      visitedLocalDeps,
+    );
   } else if (dep.version) {
     return installMopsDep(dep.name, dep.version, {
       silent,

--- a/cli/commands/install/install-deps.ts
+++ b/cli/commands/install/install-deps.ts
@@ -15,6 +15,10 @@ export async function installDeps(
   deps: Dependency[],
   { verbose, silent, threads, ignoreTransitive }: InstallDepsOptions = {},
   parentPkgPath?: string,
+  // Local `path` deps already walked in this run, by resolved directory. A
+  // default here means every top-level caller starts a fresh run, and only the
+  // recursion below carries one along.
+  visitedLocalDeps: Set<string> = new Set(),
 ): Promise<boolean> {
   let ok = true;
 
@@ -23,6 +27,7 @@ export async function installDeps(
       dep,
       { verbose, silent, threads, ignoreTransitive },
       parentPkgPath,
+      visitedLocalDeps,
     );
     if (!res) {
       ok = false;

--- a/cli/commands/install/install-local-dep.ts
+++ b/cli/commands/install/install-local-dep.ts
@@ -17,6 +17,7 @@ export async function installLocalDep(
   pkg: string,
   pkgPath = "",
   { verbose, silent, ignoreTransitive }: InstallLocalDepOptions = {},
+  visitedLocalDeps: Set<string> = new Set(),
 ): Promise<boolean> {
   if (!silent) {
     let logUpdate = createLogUpdate(process.stdout, { showCursor: true });
@@ -40,11 +41,21 @@ export async function installLocalDep(
       return true;
     }
 
+    // Two local packages can require each other. Without this the walk recurses
+    // until the stack overflows, which surfaced as a raw RangeError naming
+    // neither package. Already visited means its deps are installed, or are
+    // being installed further up this stack.
+    if (visitedLocalDeps.has(dir)) {
+      return true;
+    }
+    visitedLocalDeps.add(dir);
+
     let config = readConfig(mopsToml);
     return installDeps(
       Object.values(config.dependencies || {}),
       { silent, verbose },
       pkgPath,
+      visitedLocalDeps,
     );
   } else {
     return true;

--- a/cli/tests/path-dep-cycle.test.ts
+++ b/cli/tests/path-dep-cycle.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { rmSync } from "node:fs";
+import path from "node:path";
+import { cli } from "./helpers";
+
+// Two local packages requiring each other used to recurse through
+// installLocalDep -> installDeps -> installLocalDep until the stack overflowed,
+// exiting 1 with a raw RangeError that named neither package.
+describe("local path dependency cycles", () => {
+  jest.setTimeout(120_000);
+
+  const cleanup = (cwd: string) => {
+    rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+    rmSync(path.join(cwd, "mops.lock"), { force: true });
+  };
+
+  const fixture = (name: string) =>
+    path.join(import.meta.dirname, "path-dep-cycle", name);
+
+  test("a -> b -> a installs instead of overflowing the stack", async () => {
+    const cwd = fixture("cycle");
+    cleanup(cwd);
+    try {
+      const result = await cli(["install"], { cwd, env: { CI: "1" } });
+
+      expect(result.stderr).not.toMatch(/Maximum call stack size exceeded/);
+      expect(result.exitCode).toBe(0);
+
+      // both packages still resolve — the guard stops the walk, not the install
+      const sources = await cli(["sources"], { cwd, env: { CI: "1" } });
+      expect(sources.exitCode).toBe(0);
+      expect(sources.stdout).toMatch(/--package a /);
+      expect(sources.stdout).toMatch(/--package b /);
+    } finally {
+      cleanup(cwd);
+    }
+  });
+
+  test("a package depending on itself installs", async () => {
+    const cwd = fixture("self");
+    cleanup(cwd);
+    try {
+      const result = await cli(["install"], { cwd, env: { CI: "1" } });
+
+      expect(result.stderr).not.toMatch(/Maximum call stack size exceeded/);
+      expect(result.exitCode).toBe(0);
+    } finally {
+      cleanup(cwd);
+    }
+  });
+});

--- a/cli/tests/path-dep-cycle/cycle/a/mops.toml
+++ b/cli/tests/path-dep-cycle/cycle/a/mops.toml
@@ -1,0 +1,6 @@
+[package]
+name = "a"
+version = "1.0.0"
+
+[dependencies]
+b = "../b"

--- a/cli/tests/path-dep-cycle/cycle/b/mops.toml
+++ b/cli/tests/path-dep-cycle/cycle/b/mops.toml
@@ -1,0 +1,6 @@
+[package]
+name = "b"
+version = "1.0.0"
+
+[dependencies]
+a = "../a"

--- a/cli/tests/path-dep-cycle/cycle/mops.toml
+++ b/cli/tests/path-dep-cycle/cycle/mops.toml
@@ -1,0 +1,6 @@
+[package]
+name = "cycle-root"
+version = "1.0.0"
+
+[dependencies]
+a = "./a"

--- a/cli/tests/path-dep-cycle/self/mops.toml
+++ b/cli/tests/path-dep-cycle/self/mops.toml
@@ -1,0 +1,6 @@
+[package]
+name = "self-root"
+version = "1.0.0"
+
+[dependencies]
+me = "./"


### PR DESCRIPTION
Two local packages that require each other took down the install:

```
# root:  a = "./a"
# a:     b = "../b"
# b:     a = "../a"

$ mops install
Before: RangeError: Maximum call stack size exceeded   (exit 1)
          at readConfig (mops.ts:174:17)
          at installLocalDep (install-local-dep.ts:43:18)
          at installDeps (install-deps.ts:22:21)
          at installLocalDep (install-local-dep.ts:44:12)
          ...
After:  Packages installed                              (exit 0)
```

The stack trace named neither package, so nothing pointed at the actual problem. A package depending on itself did the same.

`installLocalDep` → `installDeps` → `installLocalDep` had no visited set, and `installDep` resolves every local dep to an absolute directory, so a cycle revisits the same path forever.

## How

The walk now carries the set of local dependency directories it has already visited in this run, keyed by that resolved absolute path, and returns early on one it has seen. Already visited means the package's dependencies are either installed or are being installed further up the same stack, so returning early is correct rather than a partial install — confirmed by the test, which asserts both `a` and `b` still reach `mops sources`.

The set is threaded through the three functions instead of living as module state. Module state would leak between in-process tests, which [#738](https://github.com/caffeinelabs/mops/pull/738) has just made possible. Each top-level caller defaults to a fresh set, so no existing call site changes.

Cycles terminate quietly rather than erroring. That is deliberate and matches the two guards already in the tree — the lockfile hasher got one in [#727](https://github.com/caffeinelabs/mops/pull/727), the resolver in [#735](https://github.com/caffeinelabs/mops/pull/735) — so all three walks over local path deps now behave the same way. Rejecting a cycle outright would be a separate decision about whether mutual local dependencies are legal, and there is no reason to bundle it with fixing a crash.

This is the last of those three unguarded walks. Item 4 in [#723](https://github.com/caffeinelabs/mops/issues/723) can close with it.

## Verification

The two new tests reproduce the crash exactly against the unpatched code — reverting the three source files fails them with `RangeError: Maximum call stack size exceeded`, which is how I confirmed the guard is load-bearing rather than incidentally passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
