### PR TITLE
ci: cache the binaries postinstall downloads, not just package tarballs

### DIFF
--- a/.github/actions/cache-rust-wasm/action.yml
+++ b/.github/actions/cache-rust-wasm/action.yml
@@ -10,3 +10,18 @@ runs:
         restore-keys: |
           rust-wasm-${{ runner.os }}-
         path: target
+
+    # `wasm-pack build` downloads Binaryen for wasm-opt into its own cache dir,
+    # at build time rather than install time — so caching node_modules does not
+    # cover it, and a GitHub outage fails the build. Keyed on the lockfile
+    # because that is what pins the wasm-pack version choosing the Binaryen
+    # release; restore-keys are safe here since wasm-pack re-downloads whatever
+    # is missing.
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        key: wasm-pack-tools-${{ runner.os }}-${{ hashFiles('cli/package-lock.json') }}
+        restore-keys: |
+          wasm-pack-tools-${{ runner.os }}-
+        path: |
+          ~/.cache/.wasm-pack
+          ~/Library/Caches/.wasm-pack

--- a/.github/actions/setup-cli-deps/action.yml
+++ b/.github/actions/setup-cli-deps/action.yml
@@ -1,0 +1,56 @@
+name: Set up cli dependencies
+description: >
+  Restore cli/node_modules and make sure cli/dist is built. setup-node's
+  `cache: npm` only caches ~/.npm, the package tarballs — `npm ci` still runs
+  postinstall scripts, and wasm-pack and @dfinity/pic each download a binary
+  from GitHub releases at that point. A GitHub blip therefore takes out every
+  job before any repo code runs, which is exactly what happened on 2026-08-12.
+  Those binaries land inside node_modules, so caching the tree removes both
+  downloads.
+
+inputs:
+  node-version:
+    description: >
+      Node major in use. Part of the cache key: native artifacts are built for
+      one ABI, so a matrix leg must never restore another leg's node_modules.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # No restore-keys on purpose. A near-miss restore would hand us a tree
+    # built from a different lockfile, and the install below would be skipped,
+    # so the only safe hit is an exact one.
+    # ImageOS distinguishes ubuntu22 from ubuntu24, which runner.os does not —
+    # they can hold incompatible native binaries.
+    - id: cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: cli/node_modules
+        key: cli-node-modules-${{ runner.os }}-${{ env.ImageOS }}-${{ runner.arch }}-node${{ inputs.node-version }}-${{ hashFiles('cli/package-lock.json') }}
+
+    # `npm ci` wipes node_modules before installing, so it has to be skipped
+    # entirely for the cache to be worth anything. Retried because this is the
+    # step that reaches out to GitHub releases on a miss.
+    - name: Install cli dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd cli
+        for attempt in 1 2 3; do
+          if npm ci; then
+            exit 0
+          fi
+          echo "::warning::npm ci failed (attempt ${attempt} of 3), retrying in 15s"
+          sleep 15
+        done
+        echo "::error::npm ci failed after 3 attempts"
+        exit 1
+
+    # On a miss `npm ci` ran `prepare` for us. On a hit nothing has built dist/
+    # yet, and it is a build output of the working tree rather than of the
+    # lockfile, so it is rebuilt rather than cached.
+    - name: Build cli dist
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: cd cli && npm run prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,16 @@ jobs:
             ~/.cache/mops
             ~/Library/Caches/mops
 
+      # cli is installed separately so it can come from the node_modules cache;
+      # the rest still install in parallel.
       - name: Install npm packages
         run: |
           npm ci --ignore-scripts
-          npm run ci:postinstall
+          npm run ci:postinstall:sites
+
+      - uses: ./.github/actions/setup-cli-deps
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install mops
         run: npm i -g ./cli/dist
@@ -144,12 +150,13 @@ jobs:
 
       # Only the CLI workspace. The frontend, docs, blog and cli-releases
       # installs belong to the `sites` job; nothing under cli/tests reaches for
-      # them. `npm ci` in cli/ runs its `prepare` script, and that is what
-      # builds the dist/ installed globally below.
+      # them. The cli setup below is what produces the dist/ installed globally.
       - name: Install npm packages
-        run: |
-          npm ci --ignore-scripts
-          cd cli && npm ci
+        run: npm ci --ignore-scripts
+
+      - uses: ./.github/actions/setup-cli-deps
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install mops
         run: npm i -g ./cli/dist
@@ -200,9 +207,11 @@ jobs:
       - uses: ./.github/actions/cache-rust-wasm
 
       - name: Install npm packages
-        run: |
-          npm ci --ignore-scripts
-          cd cli && npm ci
+        run: npm ci --ignore-scripts
+
+      - uses: ./.github/actions/setup-cli-deps
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Build and install bundle
         run: |

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -60,9 +60,10 @@ jobs:
       - uses: ./.github/actions/cache-rust-wasm
         if: ${{ matrix.mops-version == './cli/dist' }}
 
-      - name: Install and build local cli
+      - uses: ./.github/actions/setup-cli-deps
         if: ${{ matrix.mops-version == './cli/dist' }}
-        run: cd cli && npm ci
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Install mops
         run: npm i -g ${{ matrix.mops-version }}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prepare": "husky",
     "postinstall": "(cd frontend && npm install) && (cd cli && npm install) && (cd docs && npm install) && (cd blog && npm install) && (cd cli-releases && npm install)",
     "ci:postinstall": "(cd frontend && npm ci) & p1=$!; (cd cli && npm ci) & p2=$!; (cd docs && npm ci) & p3=$!; (cd blog && npm ci) & p4=$!; (cd cli-releases && npm ci) & p5=$!; wait $p1 && wait $p2 && wait $p3 && wait $p4 && wait $p5",
+    "ci:postinstall:sites": "(cd frontend && npm ci) & p1=$!; (cd docs && npm ci) & p2=$!; (cd blog && npm ci) & p3=$!; (cd cli-releases && npm ci) & p4=$!; wait $p1 && wait $p2 && wait $p3 && wait $p4",
     "test": "mops test && npm --prefix cli test",
     "check:cli": "npm run --prefix ./cli check",
     "check:frontend": "npm run --prefix ./frontend check",


### PR DESCRIPTION
On 2026-08-12 a GitHub blip failed **every job on two PRs** in the dependency-install step, before any repo code ran:

```
npm error command sh -c node ./install.js          # wasm-pack
npm error Error fetching release: socket hang up

npm error command sh -c node ./postinstall.mjs     # @dfinity/pic
npm error TypeError: fetch failed

Error: failed to download .../binaryen/releases/download/version_117/...tar.gz
```

Caching was already configured and covered none of it. `setup-node`'s `cache: "npm"` caches `~/.npm` — the package *tarballs*. `npm ci` still runs postinstall scripts, and those pull binaries from GitHub releases on every single run. Re-running the job was the only recourse.

## What changes

A new `setup-cli-deps` action caches `cli/node_modules`, which is where both `wasm-pack` and `@dfinity/pic` put their downloaded binaries, so a cache hit skips both downloads entirely.

Two details that are load-bearing rather than incidental:

**`npm ci` wipes `node_modules` before installing**, so caching it is worthless unless the install is skipped outright on a hit. That in turn skips the `prepare` script — which is what builds the `dist/` these jobs install globally — so a hit runs `npm run prepare` explicitly. `dist/` itself is deliberately *not* cached: it is a build output of the working tree, not of the lockfile, so caching it against a lockfile key would serve stale builds.

**The key is exact, with no `restore-keys`.** Everywhere else in this repo restore-keys are right, because those caches are additive and a partial hit just means re-downloading the remainder. Here a near-miss would hand back a tree built from a *different* lockfile while the install is skipped, which is silently wrong. The key also includes the Node major and `ImageOS`, since native artifacts are ABI-specific and `runner.os` cannot distinguish ubuntu22 from ubuntu24 — a matrix leg must not restore another leg's binaries.

**Binaryen is fetched at build time, not install time** (`wasm-pack build` pulling wasm-opt), so `node_modules` does not cover it. `cache-rust-wasm` now also caches wasm-pack's own tool directory. Restore-keys *are* safe there — wasm-pack re-downloads whatever version is missing.

The install retries three times, which covers the remaining case: a cold cache landing during an outage.

## The sites job

It installed cli through `ci:postinstall`'s five parallel `npm ci` calls, so it could not use the action as-is. That script gains a cli-less variant and the job uses the action for cli. Net effect on a miss is that cli installs serially rather than as one of five in parallel; on a hit it does not install at all.

## What is unchanged

Root installs already pass `--ignore-scripts`, so they never ran these postinstalls and are untouched. `release.yml` still installs the old way — it does not run on pull requests, and changing the release path to chase CI flakiness is not a trade I would make here.

Item 38 in [#723](https://github.com/caffeinelabs/mops/issues/723), filed from this exact outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
