### PR TITLE
fix(cli): write mops.lock with sorted keys

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- `mops.lock` is now written with all keys sorted — dependencies, packages, per-file hashes, graph entries and GitHub entries — so unrelated installs no longer produce diff churn or spurious merge conflicts. The lockfile format is unchanged: an existing lockfile with unsorted keys stays valid, still passes `mops install --locked`, and is reordered only the next time something legitimately updates it.
+
 - `mops install` no longer crashes with a raw `RangeError: Maximum call stack size exceeded` when two local `path` dependencies require each other, or when one requires itself. The install walk now skips a local package it has already visited in the same run, naming neither a cycle nor an error — the packages install normally.
 
 - Fixed `mops remove <pkg>` crashing with `Invalid dependency value ""` when the dependency is a local path dep.

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -690,6 +690,44 @@ async function computeLockFile(): Promise<LockFileV3> {
   };
 }
 
+// Plain code-unit sort. `localeCompare` would order keys differently depending
+// on the machine's locale, which is exactly the churn this removes.
+function sortKeys<T>(record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+  );
+}
+
+function sortNestedKeys<T>(
+  record: Record<string, Record<string, T>>,
+): Record<string, Record<string, T>> {
+  return sortKeys(
+    Object.fromEntries(
+      Object.entries(record).map(
+        ([key, inner]): [string, Record<string, T>] => [key, sortKeys(inner)],
+      ),
+    ),
+  );
+}
+
+// `mops.lock` is committed, diffed and merged like source, so its key order must
+// depend only on content — never on resolution or traversal order, which shift
+// for reasons unrelated to what was installed. Only what gets written is sorted:
+// an already-committed unsorted lock stays valid and is reordered whenever
+// something legitimately rewrites it, so this churns nobody's lock on upgrade.
+function serializeLockFile(lock: LockFileV3): string {
+  // Re-assigning an existing key keeps its original position, so the top-level
+  // field order of `computeLockFile`'s literal survives the spread.
+  let sorted: LockFileV3 = {
+    ...lock,
+    deps: sortKeys(lock.deps),
+    hashes: sortNestedKeys(lock.hashes),
+    ...(lock.graph && { graph: sortNestedKeys(lock.graph) }),
+    ...(lock.github && { github: sortKeys(lock.github) }),
+  };
+  return JSON.stringify(sorted, null, 2);
+}
+
 // Stage into a sibling temp file and atomic-rename onto the lock, so a
 // concurrent `mops install` never reads a half-written lock.
 function writeLockFileAtomic(lockFile: string, content: string) {
@@ -719,7 +757,7 @@ export async function updateLockFile({
   let lockFileJson = await computeLockFile();
   let lockFile = getLockFilePath();
   let isNew = !fs.existsSync(lockFile);
-  writeLockFileAtomic(lockFile, JSON.stringify(lockFileJson, null, 2));
+  writeLockFileAtomic(lockFile, serializeLockFile(lockFileJson));
   if (isNew && !silent) {
     console.log("mops.lock created. Commit this file.");
   }

--- a/cli/tests/lockfile-ordering.test.ts
+++ b/cli/tests/lockfile-ordering.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { cli } from "./helpers";
+
+// mops.lock is committed, diffed and merged like source, so its key order must
+// depend only on content. Targeted assertions, no snapshots (see AGENTS.md).
+describe("mops.lock key ordering", () => {
+  jest.setTimeout(180_000);
+
+  // Dedicated fixture: Jest runs test files in parallel, so sharing one with
+  // another suite would race on mops.lock / .mops.
+  const cwd = path.join(import.meta.dirname, "lockfile-ordering");
+  const lockFile = path.join(cwd, "mops.lock");
+  const tomlFile = path.join(cwd, "mops.toml");
+  const originalToml = readFileSync(tomlFile, "utf8");
+
+  const cleanup = () => {
+    writeFileSync(tomlFile, originalToml);
+    rmSync(lockFile, { force: true });
+    rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+  };
+
+  const install = async (args: string[] = []) =>
+    await cli(["install", ...args], { cwd, env: { CI: undefined } });
+
+  const readLock = () => JSON.parse(readFileSync(lockFile, "utf8"));
+  const writeLock = (lock: unknown) =>
+    writeFileSync(lockFile, JSON.stringify(lock, null, 2));
+
+  // Default sort is code-unit, matching the implementation. Using
+  // `localeCompare` here would let a locale-sensitive bug pass.
+  const expectSorted = (keys: string[]) =>
+    expect(keys).toEqual([...keys].sort());
+
+  // Descending, not `.reverse()`: reversing whatever order the writer happened
+  // to produce can land back on sorted, which would silently void the
+  // "this really is unsorted" preconditions below.
+  const descKeys = <T>(record: Record<string, T>): Record<string, T> =>
+    Object.fromEntries(
+      Object.entries(record).sort(([a], [b]) => (a < b ? 1 : a > b ? -1 : 0)),
+    );
+
+  const descNested = (record: Record<string, Record<string, string>>) =>
+    descKeys(
+      Object.fromEntries(
+        Object.entries(record).map(([key, inner]) => [key, descKeys(inner)]),
+      ),
+    );
+
+  test("writes sorted deps, hashes, per-package file keys and graph", async () => {
+    cleanup();
+    try {
+      expect((await install()).exitCode).toBe(0);
+      const lock = readLock();
+
+      // mops.toml declares the deps in reverse alphabetical order, so a lock
+      // that merely echoed the manifest would fail this.
+      expect(Object.keys(lock.deps).length).toBeGreaterThan(1);
+      expectSorted(Object.keys(lock.deps));
+
+      expect(Object.keys(lock.hashes).length).toBeGreaterThan(1);
+      expectSorted(Object.keys(lock.hashes));
+
+      const perPackage = Object.values(lock.hashes) as Record<string, string>[];
+      // At least one package must have several files, or the nested assertion
+      // below would be vacuous.
+      expect(
+        Math.max(...perPackage.map((files) => Object.keys(files).length)),
+      ).toBeGreaterThan(1);
+      for (const files of perPackage) {
+        expectSorted(Object.keys(files));
+      }
+
+      expectSorted(Object.keys(lock.graph));
+      for (const edges of Object.values(lock.graph) as Record<
+        string,
+        string
+      >[]) {
+        expectSorted(Object.keys(edges));
+      }
+
+      // Sorting is a serialization detail; the format is unchanged.
+      expect(lock.version).toBe(3);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // The carry-over path copies an already-locked package's hash record verbatim
+  // out of the old lock, so this is the case that a sort applied anywhere but at
+  // write time would miss.
+  test("sorts per-file hash keys carried over from an existing lock", async () => {
+    cleanup();
+    try {
+      writeFileSync(
+        tomlFile,
+        '[package]\nname = "lockfile-ordering"\nversion = "1.0.0"\n\n[dependencies]\ncore = "1.0.0"\n',
+      );
+      expect((await install()).exitCode).toBe(0);
+
+      const lock = readLock();
+      lock.hashes["core@1.0.0"] = descKeys(lock.hashes["core@1.0.0"]);
+      const scrambled = Object.keys(lock.hashes["core@1.0.0"]);
+      expect(scrambled).not.toEqual([...scrambled].sort());
+      writeLock(lock);
+
+      // Restoring the second dependency makes the lock legitimately stale, so
+      // it gets rewritten and core@1.0.0's hashes are carried over.
+      writeFileSync(tomlFile, originalToml);
+      expect((await install()).exitCode).toBe(0);
+
+      const rewritten = readLock();
+      expectSorted(Object.keys(rewritten.hashes["core@1.0.0"]));
+      expectSorted(Object.keys(rewritten.hashes));
+      expectSorted(Object.keys(rewritten.deps));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("regenerating an already-sorted lock is byte-identical", async () => {
+    cleanup();
+    try {
+      expect((await install()).exitCode).toBe(0);
+      const first = readFileSync(lockFile, "utf8");
+
+      rmSync(lockFile, { force: true });
+      expect((await install()).exitCode).toBe(0);
+      expect(readFileSync(lockFile, "utf8")).toBe(first);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Key order is irrelevant to every reader, so an unsorted lock committed by an
+  // older CLI must keep working. Sorting applies only to what gets written —
+  // treating "unsorted" as stale would churn every user's lock on their next
+  // install and break --locked on a lock that is otherwise perfectly good.
+  test("an unsorted lock stays valid under --locked and is not rewritten", async () => {
+    cleanup();
+    try {
+      expect((await install()).exitCode).toBe(0);
+
+      const lock = readLock();
+      lock.deps = descKeys(lock.deps);
+      lock.hashes = descNested(lock.hashes);
+      if (lock.graph) {
+        lock.graph = descNested(lock.graph);
+      }
+      writeLock(lock);
+      const unsorted = readFileSync(lockFile, "utf8");
+      expect(Object.keys(readLock().deps)).not.toEqual(
+        [...Object.keys(readLock().deps)].sort(),
+      );
+
+      const locked = await cli(["install", "--locked"], {
+        cwd,
+        env: { CI: undefined },
+      });
+      expect(locked.exitCode).toBe(0);
+      expect(readFileSync(lockFile, "utf8")).toBe(unsorted);
+
+      // A plain install must not rewrite it either: being unsorted is not a
+      // staleness trigger.
+      expect((await install()).exitCode).toBe(0);
+      expect(readFileSync(lockFile, "utf8")).toBe(unsorted);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/cli/tests/lockfile-ordering/mops.toml
+++ b/cli/tests/lockfile-ordering/mops.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lockfile-ordering"
+version = "1.0.0"
+
+# Declared in reverse alphabetical order on purpose: the lock must come out
+# sorted regardless of how mops.toml lists them.
+[dependencies]
+test = "2.1.2"
+core = "1.0.0"

--- a/docs/docs/10-mops.lock.md
+++ b/docs/docs/10-mops.lock.md
@@ -134,6 +134,12 @@ For the same reason, updating a stale lock carries file hashes of already-locked
 
 Local path dependencies are stored relative to the project root (e.g. `./packages/shared`, `../lib`) so the lockfile is portable across machines. A lockfile that still carries absolute paths from an older CLI is treated as stale and rewritten by a plain `mops install`. After regenerating, use a CLI that includes this fix; older CLIs treat relative lock paths as cwd-relative and break when run from a subdirectory.
 
+## Key ordering
+
+Every key Mops writes to `mops.lock` is sorted — the dependencies, the packages in `hashes`, the per-file hashes within each package, the `graph` entries and the `github` entries. Ordering never depends on how `mops.toml` lists dependencies or on the order resolution happened to visit them, so unrelated installs produce no diff churn and the file merges cleanly.
+
+Ordering is not a correctness property: a lockfile written by an older CLI with unsorted keys stays valid, passes `mops install --locked`, and is not rewritten just for being unsorted. It is reordered the next time something legitimately updates it.
+
 ## `{MOPS_ENV}` path dependencies
 
 A local `path` dependency may contain `{MOPS_ENV}`, which expands to the value of the `MOPS_ENV` environment variable (`local` when it is unset):


### PR DESCRIPTION
`mops.lock` was serialized with a plain `JSON.stringify`, so `deps`, `hashes`, `graph` and `github` came out in insertion/traversal order. This repo's own lockfile is ~69 KB with 621 per-file hash entries, so an install unrelated to a given package could still reorder its block — diff churn and merge conflicts for no reason.

Every key is now sorted: the sections, the package keys inside `hashes`, the per-file hash keys inside each package, and `graph`'s inner per-version edge maps.

## Two details that decide whether this actually works

**Sorting happens at the single write site, not where records are computed.** `computeLockFile` carries an existing package's hash record over verbatim when its version has not changed — that is a deliberate optimisation, since published versions are immutable. A sort applied at computation time would therefore preserve whatever order a carried-over record already had, and the file would never converge. There is a test for exactly this: it scrambles an existing lock's file-key order, makes the lock legitimately stale so it gets rewritten, and asserts the carried-over record comes out sorted.

**Plain code-unit comparison, never `localeCompare`.** A locale-sensitive sort orders differently depending on the machine's locale, which would make the lockfile *less* reproducible than before.

## Not a format change

`CURRENT_LOCK_VERSION` stays `3`. Validation never inspects key position — `hasValidShape`, `inspectLockFile`, `checkLockedDeps`, `checkLockedGithubDeps` and `checkLockConsistency` all index by name or compare key sets — so key order is invisible to every reader.

An existing unsorted lockfile therefore **stays valid**, still passes `mops install --locked`, and is reordered only the next time something legitimately updates it. It is deliberately *not* treated as stale: a "rewrite because unsorted" trigger would churn every user's lockfile on their next install for no correctness reason, and would fail `--locked` on a lock that is otherwise perfectly good. A test pins both halves — an unsorted lock passes `--locked` and is byte-identical afterwards, and a plain `mops install` also leaves it byte-identical. That second assertion is the regression guard against someone adding such a trigger later.

## Verification

`locked`, `cache-resilience`, `local-dep-manifest-lock` and the new `lockfile-ordering` suites: 40/40. The new tests were confirmed to bite by reverting the call site — the two ordering tests fail without it, while the two `--locked` guarantees correctly pass either way, since they assert behaviour that must hold before *and* after.

`github-dep-lock.test.ts` fails locally, and it is not from this change: with the call site reverted the same suite fails a *superset* of those tests, and the count varies run to run. It downloads real archives from GitHub and that cache has been churned repeatedly today. Worth a look if CI disagrees.

Item 8 in [#723](https://github.com/caffeinelabs/mops/issues/723), where the triage records that this needs no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
