### PR TITLE
perf(cli): resolve the dependency graph once per command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 - File metadata and the first chunk of each file are now fetched concurrently rather than chained, halving per-file round trips for the single-chunk case that covers essentially every Motoko source file.
 - Chunk concatenation is no longer quadratic. **Breaking for programmatic consumers of the `ic-mops` package**: `downloadFile` and `downloadPackageFiles` now return `Uint8Array` instead of `Array<number>`.
 - `mops outdated` and `mops update` no longer make a registry call when a project has no registry dependencies to check.
+- **Dependency resolution runs once per command instead of three to five times.** A command resolves at several points (local cache sync, lockfile write, requirements check, `mops sources`), each of which used to re-walk the whole dependency graph. The walk is now memoized in-process on the *content* of `mops.toml` and `mops.lock` plus every local `path` dependency manifest it reads, so a command that rewrites its own inputs — `mops install` writing the lockfile, `mops add` writing `mops.toml` — still re-walks and cannot act on a stale graph.
 
 ### Integrity
 

--- a/cli/resolve-packages.ts
+++ b/cli/resolve-packages.ts
@@ -1,7 +1,9 @@
 import process from "node:process";
 import path from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import chalk from "chalk";
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
 import {
   checkConfigFile,
   getRootDir,
@@ -22,9 +24,11 @@ import {
   readLockFileGraph,
 } from "./integrity.js";
 
-// A single command resolves several times (local cache sync, lockfile write,
-// integrity check), so remember what has been reported to keep one conflict
-// from being printed three times.
+// Repeat resolves with identical inputs are collapsed by the memo below, so
+// what is left to guard is a command that rewrites its own inputs mid-run —
+// `checkIntegrity` writes mops.lock, `add`/`remove`/`update` write mops.toml.
+// That produces a new key and a second walk, which must not re-print a
+// conflict the first walk already reported.
 const reportedConflicts = new Set<string>();
 
 export type ConflictPolicy = "warning" | "error" | "ignore";
@@ -33,10 +37,12 @@ let conflictPolicy: ConflictPolicy = "warning";
 
 /**
  * How this command treats cross-major conflicts. It is a property of the
- * invocation, not of one resolve call: a single command resolves 3-5 times, and
- * `mops sources --conflicts ignore` has to silence all of them, not just the
- * last. So the CLI sets the policy up front rather than threading an option
- * down through installAll, the lockfile and the integrity check.
+ * invocation, not of one resolve call: a command can resolve more than once
+ * (the memo collapses the repeats, but writing mops.lock or mops.toml mid-run
+ * forces a fresh walk), and `mops sources --conflicts ignore` has to silence
+ * all of them, not just the last. So the CLI sets the policy up front rather
+ * than threading an option down through installAll, the lockfile and the
+ * integrity check.
  */
 export function setConflictPolicy(policy: ConflictPolicy) {
   conflictPolicy = policy;
@@ -48,6 +54,66 @@ export async function resolvePackages({ skipLock = false } = {}): Promise<
   return (await resolveDepsAndGraph({ skipLock })).deps;
 }
 
+export type ResolveResult = {
+  deps: Record<string, string>;
+  graph: Record<string, Record<string, string>>;
+};
+
+// In-process only, never written to disk. A single command resolves 3-5 times
+// (local cache sync, lockfile write, requirements check, `mops sources`), and
+// rewrites its own inputs while doing so — `checkIntegrity` writes mops.lock,
+// `add`/`remove`/`update` write mops.toml — so the key is the *content* of
+// both, not their paths.
+type ResolveCacheEntry = {
+  key: string;
+  promise: Promise<ResolveResult>;
+  // Local `path` dep manifests the walk read. Unknown until it finishes, and
+  // they are live directories rather than immutable published versions, so a
+  // hit re-checks them instead of trusting the key alone.
+  localInputs: Map<string, string> | null;
+};
+
+let resolveCache: ResolveCacheEntry | null = null;
+
+// "" for a file that does not exist, so creating or deleting one invalidates.
+function fileHash(file: string): string {
+  try {
+    return bytesToHex(sha256(readFileSync(file)));
+  } catch {
+    return "";
+  }
+}
+
+// `skipLock` is keyed by what it changes, not by its value: it only suppresses
+// the lock short-circuit, so with no usable lock both variants walk the same
+// graph. That is what lets a cold install's two resolves — sync, then lockfile
+// regeneration — share a single walk.
+function resolveCacheKey(rootDir: string, usesLock: boolean): string {
+  return [
+    rootDir,
+    usesLock,
+    conflictPolicy,
+    process.env.MOPS_ENV || "",
+    fileHash(path.join(rootDir, "mops.toml")),
+    fileHash(path.join(rootDir, "mops.lock")),
+  ].join("|");
+}
+
+// Callers iterate the result and the lockfile writer embeds it, so hand out a
+// copy rather than the memoized object. Deep for `graph`, whose values are
+// themselves maps a caller could otherwise mutate into the memo.
+function copyResult(result: ResolveResult): ResolveResult {
+  return {
+    deps: { ...result.deps },
+    graph: Object.fromEntries(
+      Object.entries(result.graph).map(([pkgId, edges]) => [
+        pkgId,
+        { ...edges },
+      ]),
+    ),
+  };
+}
+
 // Resolves winners and collects the declared dependency edges of every
 // registry package version visited (losers included), so the lock can be
 // regenerated later without those versions on disk.
@@ -55,15 +121,67 @@ export async function resolveDepsAndGraph({
   // Bypass a valid lock so lock regeneration re-reads mops.toml (this is how
   // absolute local paths from older CLIs get rewritten root-relative).
   skipLock = false,
-} = {}): Promise<{
-  deps: Record<string, string>;
-  graph: Record<string, Record<string, string>>;
-}> {
+} = {}): Promise<ResolveResult> {
   if (!checkConfigFile()) {
     return { deps: {}, graph: {} };
   }
 
-  if (!skipLock && checkLockFileLight()) {
+  let rootDir = getRootDir();
+  let usesLock = !skipLock && checkLockFileLight();
+  let key = resolveCacheKey(rootDir, usesLock);
+
+  let cached = resolveCache;
+  if (
+    cached &&
+    cached.key === key &&
+    // null means the walk is still running: a concurrent caller shares it.
+    (cached.localInputs === null ||
+      [...cached.localInputs].every(([file, hash]) => fileHash(file) === hash))
+  ) {
+    return copyResult(await cached.promise);
+  }
+
+  let localInputs = new Map<string, string>();
+  let entry: ResolveCacheEntry = {
+    key,
+    localInputs: null,
+    promise: resolveUncached(usesLock, rootDir, localInputs),
+  };
+  resolveCache = entry;
+
+  try {
+    let result = await entry.promise;
+    entry.localInputs = localInputs;
+    return copyResult(result);
+  } catch (err) {
+    // A failed walk must not be served to the next caller.
+    if (resolveCache === entry) {
+      resolveCache = null;
+    }
+    throw err;
+  }
+}
+
+// The winner of each dependency name, and every version of it the walk saw.
+type ResolvedPackages = Record<
+  string,
+  Dependency & { isRoot: boolean; identity: string }
+>;
+type VersionSightings = Record<
+  string,
+  Array<{
+    isMopsPackage: boolean;
+    version: string;
+    dependencyOf: string;
+  }>
+>;
+
+async function resolveUncached(
+  usesLock: boolean,
+  rootDir: string,
+  localInputs: Map<string, string>,
+): Promise<ResolveResult> {
+  if (usesLock) {
     let lockFileJson = readLockFile();
 
     if (lockFileJson && lockFileJson.version === 3) {
@@ -86,19 +204,8 @@ export async function resolveDepsAndGraph({
   // stops a local `path` dep cycle from recursing until the stack overflows.
   let walked = new Set<string>();
 
-  let rootDir = getRootDir();
-  let packages: Record<
-    string,
-    Dependency & { isRoot: boolean; identity: string }
-  > = {};
-  let versions: Record<
-    string,
-    Array<{
-      isMopsPackage: boolean;
-      version: string;
-      dependencyOf: string;
-    }>
-  > = {};
+  let packages: ResolvedPackages = {};
+  let versions: VersionSightings = {};
 
   const gitVerRegex = /v(\d{1,2}\.\d{1,2}\.\d{1,2})(-.*)?$/;
 
@@ -179,6 +286,9 @@ export async function resolveDepsAndGraph({
       // read nested config (github deps have none)
       if (pkgDetails.path) {
         let mopsToml = path.join(localNestedDir, "mops.toml");
+        // recorded before the existence check, so creating a manifest where
+        // there was none invalidates the memo too
+        localInputs.set(mopsToml, fileHash(mopsToml));
         if (existsSync(mopsToml)) {
           nestedConfig = readConfig(mopsToml);
         }
@@ -276,91 +386,7 @@ export async function resolveDepsAndGraph({
   let config = readConfig();
   await collectDeps(config, rootDir, true);
 
-  // Cross-major conflicts report by default on every path that resolves, not
-  // just where a caller opted in: handing a dependency a different major than
-  // it asked for changes the API it compiles against. `ignore` remains a real
-  // opt-out, because `mops sources` runs on every build of a project that uses
-  // it as a packtool, and one that has knowingly accepted an override needs a
-  // way to stop the noise.
-  // Same-major skew stays silent.
-  let hasConflicts = false;
-
-  if (conflictPolicy !== "ignore") {
-    for (let [dep, vers] of Object.entries(versions)) {
-      // Only registry deps carry comparable majors; git refs are excluded.
-      let mopsVers = [...vers].reverse().filter((x) => x.isMopsPackage);
-      let majors = new Set(mopsVers.map((x) => majorVersion(x.version)));
-
-      if (majors.size < 2) {
-        continue;
-      }
-
-      hasConflicts = true;
-
-      // Keyed on the conflict itself, not just the dependency name, so the 3-5
-      // resolution passes in one command collapse to one report while a
-      // genuinely different set of dependents still gets through.
-      let conflictKey = `${dep}:${mopsVers
-        .map((x) => `${x.version}@${x.dependencyOf}`)
-        .sort()
-        .join(",")}`;
-      if (reportedConflicts.has(conflictKey)) {
-        continue;
-      }
-      reportedConflicts.add(conflictKey);
-
-      console.error(
-        chalk.reset("") + chalk.redBright("Warning!"),
-        `Conflicting major versions of dependency "${dep}"`,
-      );
-
-      let seen = new Set<string>();
-      for (let { version, dependencyOf } of mopsVers) {
-        // Highlight the same major the conflict was detected on, so what is
-        // displayed cannot drift from what was compared.
-        let rest = version.split(".").slice(1).join(".");
-        let dependent = dependencyOf || "<unknown>";
-        if (seen.has(`${version} ${dependent}`)) {
-          continue;
-        }
-        seen.add(`${version} ${dependent}`);
-        console.error(
-          chalk.reset("  ") +
-            `${dep} ${chalk.bold.red(majorVersion(version))}${rest ? `.${rest}` : ""} is a dependency of ${chalk.bold(dependent)}`,
-        );
-      }
-
-      let winner = packages[dep];
-      if (winner) {
-        // Alias keys like `core@1` are not bare TOML keys.
-        let tomlKey = /^[\w-]+$/.test(dep) ? dep : `"${dep}"`;
-        // Local and GitHub deps resolve to a path or repo, not a version, so
-        // the root can win the conflict without naming a version at all.
-        let override = winner.repo || winner.path;
-        console.error(
-          chalk.reset("  ") +
-            (winner.version
-              ? `Resolved to ${chalk.bold(`${dep} ${winner.version}`)}`
-              : `Resolved to the ${winner.isRoot ? "root " : ""}override ${chalk.bold(`${tomlKey} = "${override}"`)}`) +
-            ` — dependents on another major compile against an API they did not ask for.`,
-        );
-        console.error(
-          chalk.reset("  ") +
-            `If you want a different version, pin it in your root mops.toml — a root dependency always wins.`,
-        );
-      }
-    }
-
-    // The report above is always a warning, so escalation is a separate line
-    // rather than a relabelled duplicate of a report an earlier pass printed.
-    if (conflictPolicy === "error" && hasConflicts) {
-      console.error(
-        chalk.reset("") + chalk.redBright("Error!"),
-        "Cross-major dependency conflicts found, failing because --conflicts error was requested",
-      );
-      process.exit(1);
-    }
-  }
+  reportCrossMajorConflicts(versions, packages);
 
   // The walk visits every declared edge, losers included, because the lock's
   // `graph` needs their manifests. What gets installed is narrower: the closure
@@ -409,4 +435,97 @@ export async function resolveDepsAndGraph({
   );
 
   return { deps, graph };
+}
+
+// Cross-major conflicts report by default on every path that resolves, not
+// just where a caller opted in: handing a dependency a different major than
+// it asked for changes the API it compiles against. `ignore` remains a real
+// opt-out, because `mops sources` runs on every build of a project that uses
+// it as a packtool, and one that has knowingly accepted an override needs a
+// way to stop the noise.
+// Same-major skew stays silent.
+function reportCrossMajorConflicts(
+  versions: VersionSightings,
+  packages: ResolvedPackages,
+) {
+  if (conflictPolicy === "ignore") {
+    return;
+  }
+
+  let hasConflicts = false;
+
+  for (let [dep, vers] of Object.entries(versions)) {
+    // Only registry deps carry comparable majors; git refs are excluded.
+    let mopsVers = [...vers].reverse().filter((x) => x.isMopsPackage);
+    let majors = new Set(mopsVers.map((x) => majorVersion(x.version)));
+
+    if (majors.size < 2) {
+      continue;
+    }
+
+    hasConflicts = true;
+
+    // Keyed on the conflict itself, not just the dependency name, so a second
+    // walk forced by changed inputs collapses to one report while a genuinely
+    // different set of dependents still gets through.
+    let conflictKey = `${dep}:${mopsVers
+      .map((x) => `${x.version}@${x.dependencyOf}`)
+      .sort()
+      .join(",")}`;
+    if (reportedConflicts.has(conflictKey)) {
+      continue;
+    }
+    reportedConflicts.add(conflictKey);
+
+    console.error(
+      chalk.reset("") + chalk.redBright("Warning!"),
+      `Conflicting major versions of dependency "${dep}"`,
+    );
+
+    let seen = new Set<string>();
+    for (let { version, dependencyOf } of mopsVers) {
+      // Highlight the same major the conflict was detected on, so what is
+      // displayed cannot drift from what was compared.
+      let rest = version.split(".").slice(1).join(".");
+      let dependent = dependencyOf || "<unknown>";
+      if (seen.has(`${version} ${dependent}`)) {
+        continue;
+      }
+      seen.add(`${version} ${dependent}`);
+      console.error(
+        chalk.reset("  ") +
+          `${dep} ${chalk.bold.red(majorVersion(version))}${rest ? `.${rest}` : ""} is a dependency of ${chalk.bold(dependent)}`,
+      );
+    }
+
+    let winner = packages[dep];
+    if (winner) {
+      // Alias keys like `core@1` are not bare TOML keys.
+      let tomlKey = /^[\w-]+$/.test(dep) ? dep : `"${dep}"`;
+      // Local and GitHub deps resolve to a path or repo, not a version, so
+      // the root can win the conflict without naming a version at all.
+      let override = winner.repo || winner.path;
+      console.error(
+        chalk.reset("  ") +
+          (winner.version
+            ? `Resolved to ${chalk.bold(`${dep} ${winner.version}`)}`
+            : `Resolved to the ${winner.isRoot ? "root " : ""}override ${chalk.bold(`${tomlKey} = "${override}"`)}`) +
+          ` — dependents on another major compile against an API they did not ask for.`,
+      );
+      console.error(
+        chalk.reset("  ") +
+          `If you want a different version, pin it in your root mops.toml — a root dependency always wins.`,
+      );
+    }
+  }
+
+  // The report above is always a warning, so escalation is a separate line
+  // rather than a relabelled duplicate of a report an earlier pass printed.
+  if (conflictPolicy === "error" && hasConflicts) {
+    console.error(
+      chalk.reset("") + chalk.redBright("Error!"),
+      "Cross-major dependency conflicts found, failing because --conflicts error was requested",
+    );
+    process.exit(1);
+  }
 }

--- a/cli/tests/resolve-memo.test.ts
+++ b/cli/tests/resolve-memo.test.ts
@@ -1,0 +1,232 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// The memo is in-process module state, so these drive `resolveDepsAndGraph`
+// directly — one CLI subprocess per resolve could never share a memo.
+//
+// Every case is checked with the same canary: the global cache's copy of a
+// published package's manifest. It is deliberately not part of the memo key
+// (published versions are immutable), so editing it is invisible to a memo hit
+// and shows up in the result only when a walk actually reruns.
+describe("resolve memoization", () => {
+  jest.setTimeout(60_000);
+
+  type ResolvePackages = typeof import("../resolve-packages.js");
+  let resolvePackages: ResolvePackages;
+
+  let cacheHome: string;
+  let cwdBefore = process.cwd();
+  let tempDirs: string[] = [];
+
+  const cachedPackage = (name: string, version: string, deps = "") => {
+    let dir = path.join(cacheHome, "mops", "packages", `${name}@${version}`);
+    mkdirSync(dir, { recursive: true });
+    let file = path.join(dir, "mops.toml");
+    writeFileSync(
+      file,
+      `[package]\nname = "${name}"\nversion = "${version}"\n\n[dependencies]\n${deps}`,
+    );
+    return file;
+  };
+
+  // The next walk — and only a walk — picks this up.
+  const armCanary = () => cachedPackage("test", "1.0.0", 'canary = "1.0.0"\n');
+  const disarmCanary = () => cachedPackage("test", "1.0.0");
+  const walked = (result: { deps: Record<string, string> }) =>
+    "canary" in result.deps;
+
+  const project = (files: Record<string, string>): string => {
+    let dir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "mops-memo-")));
+    tempDirs.push(dir);
+    write(dir, files);
+    process.chdir(dir);
+    return dir;
+  };
+
+  const write = (dir: string, files: Record<string, string>) => {
+    for (let [rel, content] of Object.entries(files)) {
+      let file = path.join(dir, rel);
+      mkdirSync(path.dirname(file), { recursive: true });
+      writeFileSync(file, content);
+    }
+  };
+
+  const root = (deps: string) =>
+    `[package]\nname = "root"\nversion = "1.0.0"\n\n[dependencies]\n${deps}`;
+
+  beforeAll(async () => {
+    // `globalCacheDir` is read at import time, so the override has to be set
+    // before the module under test is loaded.
+    cacheHome = realpathSync(
+      mkdtempSync(path.join(os.tmpdir(), "mops-memo-cache-")),
+    );
+    process.env.XDG_CACHE_HOME = cacheHome;
+    delete process.env.MOPS_ENV;
+    cachedPackage("test", "1.0.0");
+    cachedPackage("canary", "1.0.0");
+    resolvePackages = await import("../resolve-packages.js");
+  });
+
+  beforeEach(() => {
+    disarmCanary();
+  });
+
+  afterEach(() => {
+    process.chdir(cwdBefore);
+    resolvePackages.setConflictPolicy("warning");
+    delete process.env.MOPS_ENV;
+    for (let dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  afterAll(() => {
+    rmSync(cacheHome, { recursive: true, force: true });
+    delete process.env.XDG_CACHE_HOME;
+  });
+
+  test("a second resolve with identical inputs does not walk again", async () => {
+    project({ "mops.toml": root('test = "1.0.0"\na = "./a"\n') });
+
+    let first = await resolvePackages.resolveDepsAndGraph();
+    expect(walked(first)).toBe(false);
+    armCanary();
+
+    let second = await resolvePackages.resolveDepsAndGraph();
+    expect(walked(second)).toBe(false);
+    expect(second.deps).toEqual(first.deps);
+  });
+
+  test("the memoized result is copied, not shared", async () => {
+    project({ "mops.toml": root('test = "1.0.0"\n') });
+
+    armCanary();
+    let first = await resolvePackages.resolveDepsAndGraph();
+    first.deps.test = "tampered";
+    first.graph["test@1.0.0"]!.canary = "tampered";
+
+    let second = await resolvePackages.resolveDepsAndGraph();
+    expect(second.deps.test).toBe("1.0.0");
+    expect(second.graph["test@1.0.0"]).toEqual({ canary: "1.0.0" });
+  });
+
+  test("editing the root mops.toml invalidates", async () => {
+    let dir = project({ "mops.toml": root('test = "1.0.0"\n') });
+
+    await resolvePackages.resolveDepsAndGraph();
+    armCanary();
+    write(dir, { "mops.toml": root('test = "1.0.0"\nextra = "./extra"\n') });
+
+    let second = await resolvePackages.resolveDepsAndGraph();
+    expect(walked(second)).toBe(true);
+    expect(second.deps.extra).toBe("./extra");
+  });
+
+  test("a mops.lock written mid-command invalidates", async () => {
+    let dir = project({ "mops.toml": root('test = "1.0.0"\n') });
+
+    await resolvePackages.resolveDepsAndGraph();
+    armCanary();
+    // Content is what the key covers; an unusable lock still forces a re-walk.
+    write(dir, { "mops.lock": "{}" });
+
+    expect(walked(await resolvePackages.resolveDepsAndGraph())).toBe(true);
+  });
+
+  test("editing a local path dep manifest invalidates at any depth", async () => {
+    let dir = project({
+      "mops.toml": root('test = "1.0.0"\na = "./a"\n'),
+      "a/mops.toml": `[package]\nname = "a"\nversion = "1.0.0"\n\n[dependencies]\nb = "./b"\n`,
+      "a/b/mops.toml": `[package]\nname = "b"\nversion = "1.0.0"\n\n[dependencies]\n`,
+    });
+
+    await resolvePackages.resolveDepsAndGraph();
+    armCanary();
+    // two levels below the root, and reached only through another local dep
+    write(dir, {
+      "a/b/mops.toml": `[package]\nname = "b"\nversion = "1.0.0"\n\n[dependencies]\nc = "./c"\n`,
+    });
+
+    let second = await resolvePackages.resolveDepsAndGraph();
+    expect(second.deps.c).toBe("./a/b/c");
+    expect(walked(second)).toBe(true);
+  });
+
+  test("creating a local path dep manifest that did not exist invalidates", async () => {
+    let dir = project({ "mops.toml": root('test = "1.0.0"\na = "./a"\n') });
+
+    let first = await resolvePackages.resolveDepsAndGraph();
+    expect(first.deps.a).toBe("./a");
+    armCanary();
+    // the absent manifest is recorded too, so appearing counts as a change
+    write(dir, {
+      "a/mops.toml": `[package]\nname = "a"\nversion = "1.0.0"\n\n[dependencies]\nd = "./d"\n`,
+    });
+
+    let second = await resolvePackages.resolveDepsAndGraph();
+    expect(second.deps.d).toBe("./a/d");
+    expect(walked(second)).toBe(true);
+  });
+
+  test("changing MOPS_ENV invalidates", async () => {
+    project({
+      "mops.toml": root('test = "1.0.0"\nenv = "./{MOPS_ENV}-dep"\n'),
+    });
+
+    let first = await resolvePackages.resolveDepsAndGraph();
+    expect(first.deps.env).toBe("./local-dep");
+    armCanary();
+    process.env.MOPS_ENV = "staging";
+
+    let second = await resolvePackages.resolveDepsAndGraph();
+    expect(second.deps.env).toBe("./staging-dep");
+    expect(walked(second)).toBe(true);
+  });
+
+  test("changing the conflict policy invalidates", async () => {
+    project({ "mops.toml": root('test = "1.0.0"\n') });
+
+    await resolvePackages.resolveDepsAndGraph();
+    armCanary();
+    resolvePackages.setConflictPolicy("ignore");
+
+    expect(walked(await resolvePackages.resolveDepsAndGraph())).toBe(true);
+  });
+
+  test("a walk that threw is not served to the next caller", async () => {
+    let good = `[package]\nname = "a"\nversion = "1.0.0"\n\n[dependencies]\n`;
+    let dir = project({
+      "mops.toml": root('test = "1.0.0"\na = "./a"\n'),
+      "a/mops.toml": good,
+    });
+
+    let first = await resolvePackages.resolveDepsAndGraph();
+
+    write(dir, { "a/mops.toml": "this is not toml = = =" });
+    await expect(resolvePackages.resolveDepsAndGraph()).rejects.toThrow();
+
+    // Restoring the manifest restores the key of the successful walk, so a
+    // cached rejection would be handed straight back instead of re-walking.
+    write(dir, { "a/mops.toml": good });
+    let third = await resolvePackages.resolveDepsAndGraph();
+    expect(third.deps).toEqual(first.deps);
+  });
+});


### PR DESCRIPTION
A single command resolves the dependency graph at several points — local cache sync, lockfile write, requirements check, `mops sources` — and each one re-walked the whole graph from scratch, re-reading `mops.toml` and `mops.lock` every time. On a cold or stale-lock walk that also means re-downloading packages purely to read their manifests.

The walk is now memoized in-process.

## Why the key is content, not paths

Commands rewrite their own inputs mid-run: `checkIntegrity` writes `mops.lock`, and `add`/`remove`/`update` write `mops.toml`. A path-keyed memo would happily serve the pre-write graph afterwards. So the key is the *content* of both files, plus the root dir, the conflict policy and `MOPS_ENV`.

Local `path` dependencies are the interesting case: they are live directories, and their manifests are in neither file. Every manifest the walk reads is therefore recorded and re-hashed on a hit — including ones that **did not exist**, recorded as `""` before the existence check, so creating a manifest where there was none also invalidates.

Registry package manifests are deliberately *outside* the key. Published versions are immutable, so their content cannot change under us — the same assumption the lockfile's `graph` carry-over already depends on.

## How the invalidation was actually verified

A stale memo hit means a silently wrong dependency graph, which would be far worse than the redundant work it removes. So the tests don't assert on timing or call counts — they use a **canary**: a cached registry package's manifest is outside the key by design, so arming it to declare an extra dependency is invisible to a memo *hit* and shows up in `deps` only if a walk genuinely reran. `"canary" in deps` is a direct hit/miss probe.

Every case below was then mutation-tested — the relevant line was deliberately broken to confirm the test fails, so nothing passes vacuously:

| invalidates on | proof |
|---|---|
| root `mops.toml` edited | canary appears after appending a dep |
| `mops.lock` written mid-command | canary appears after writing even an unusable `{}` lock |
| local dep manifest edited, at depth | edited a manifest two levels down, reached only through another local dep |
| manifest *created* where none existed | canary appears; moving the record inside the existence check fails this test only |
| `MOPS_ENV` changed | `./local-dep` → `./staging-dep` |
| conflict policy changed | canary appears after `setConflictPolicy("ignore")` |
| the walk threw | corrupt a nested manifest, then restore it so the *successful* key matches exactly — a retained rejection would be handed straight back |

Two properties are structural rather than tested: when the lock short-circuits, the result is a pure function of `mops.lock`, which the key hashes, so an empty `localInputs` is correct rather than a gap. And `checkLockFileLight()` — hence the key — already depends on local manifests through `localDepsHash`, giving local edits a second, independent invalidation path.

**One bounded caveat**: while a walk is in flight, a concurrent caller shares the promise without re-checking local manifests. Nothing in the CLI resolves concurrently today, so it is unreachable, but it is the one place an edit landing mid-walk would be missed. Worth knowing before anyone parallelises resolution.

## Cleanup, since this file was open anyway

The ~85-line cross-major conflict report moved out of the walk into its own function, which leaves the walk doing one thing. It moved character-for-character — every message string, the dependent ordering, the de-duplication and the `--conflicts error` exit — and `resolve.test.ts` passes unchanged, including its committed stdout/stderr snapshot.

`copyResult` now deep-copies `graph`'s inner edge maps. It was shallow, so a caller mutating `graph[pkgId][dep]` would have written into the memo. No current caller does; the copy is cheap and closes the class.

`reportedConflicts` survives with a corrected comment. It no longer guards against repeated identical resolves — the memo does that now — but against the narrower case where inputs legitimately change mid-command. Leaving its old comment, which described the 3–5 passes this PR eliminates, would have actively misled the next reader. Whether conflict-reporting semantics should change at all is item 3, deliberately untouched here.

## Verification

`resolve`, `cache-resilience`, `local-path-lock`, `local-dep-manifest-lock` and the new `resolve-memo` suites: 36/36, snapshot matched. Broader sweep across `locked`, `path-dep-cycle`, `requirements`, `legacy-lock-flag`, `sync-plan`, `remove`, `remove-dry-run` and `outdated` also passes.

`github-dep-lock.test.ts` fails locally with `socket hang up` fetching `github.com/.../archive/<sha>.zip`. That is the outage tracked as item 39 — `github.com` redirects to `codeload.github.com`, and today the redirect host is failing while codeload returns 200. This PR never touches GitHub archives.

Item 6 in [#723](https://github.com/caffeinelabs/mops/issues/723).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
