### PR TITLE
feat(cli): retry installs on transient network failures, fd-aware request budget

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -98,7 +98,7 @@ Downloaded files are always checked before anything enters the cache — against
 
 Two consequences worth knowing: a corrupt or hand-edited `mops.lock` now fails a _download_ (the error names `mops.lock` as a possible culprit — restore it from version control; already-cached packages are unaffected), and a package the registry publishes no hashes for still installs, unverified, with a warning.
 
-Packages download in parallel through a bounded pool. `mops install --concurrency <n>` or the `MOPS_CONCURRENCY` env var (works on every installing command) caps simultaneous registry requests; the default derives from the CPU count (4–16). Set `MOPS_CONCURRENCY=1` in constrained environments (1-CPU containers, egress proxies) if installs hit connection errors.
+Packages download in parallel through a bounded pool. `mops install --concurrency <n>` or the `MOPS_CONCURRENCY` env var (works on every installing command) caps simultaneous registry requests; the default derives from the CPU count and the file-descriptor soft limit (4–16). Transient network errors (`fetch failed`, `ECONNRESET`, `EMFILE`) retry automatically with the concurrency halved, up to twice. Set `MOPS_CONCURRENCY=1` only if installs still fail after the retries (an egress proxy capping connections, for example).
 
 ### `mops verify`
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Installs self-heal on transient network failures.** A `fetch failed`, `ECONNRESET` or `EMFILE` during an install no longer aborts the command: the install retries up to twice with the request concurrency halved, so an environment that cannot sustain the default parallelism degrades to a slower install instead of a broken one. Packages that already downloaded come from the cache on retry, and only the failures are re-fetched. Registry answers such as "Package not found" are never retried.
+- The default request concurrency is now capped by the file-descriptor soft limit as well as the CPU count, so a many-core machine with a low `ulimit -n` no longer gets a budget wide enough to exhaust its own descriptors. The usual limits (macOS's default 256 and up) leave the budget unchanged.
 - `mops update` now exits `2` for an unknown package or a missing `mops.toml`, matching `mops outdated`. It previously exited `0` after printing `Package "<name>" is not installed!`, so a typo in a scripted update looked like success.
 - `mops update` and `mops outdated` now share one rule for deciding when a `repo = "..."` dependency is out of date, so the two commands cannot disagree about it.
 - `mops update --help` and its doc page now state that the command rewrites `mops.toml` — it is `cargo upgrade` semantics, not `cargo update` — and list its exit codes.

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -211,7 +211,7 @@ program
   .addOption(
     new Option(
       "--concurrency <n>",
-      "Max simultaneous registry requests (default: derived from the CPU count, 4–16; env var MOPS_CONCURRENCY works on every command)",
+      "Max simultaneous registry requests (default: derived from the CPU count and open-file limit, 4–16; env var MOPS_CONCURRENCY works on every command)",
     ).argParser(parseConcurrency),
   )
   .addOption(

--- a/cli/commands/install/install-concurrency.ts
+++ b/cli/commands/install/install-concurrency.ts
@@ -11,13 +11,47 @@ const MAX_REQUEST_BUDGET = 16;
 const MAX_PACKAGE_CONCURRENCY = 4;
 // installMopsDep's historical thread count, which a single package still gets.
 const MAX_FILE_THREADS = 12;
+// An in-flight request holds a socket, and the install holds more fds around
+// it (staged writes, cache copies, node's own baseline), so a request may
+// claim at most this fraction of the fd soft limit. The usual limits pass
+// untouched: macOS's default 256 still allows the full budget of 16.
+const FDS_PER_REQUEST = 16;
+
+// EMFILE is enforced against the soft limit, which node only exposes through
+// the diagnostic report (~15 ms). Read it once, and only on the install path.
+let cachedFdSoftLimit: number | undefined;
+
+export function fdSoftLimit(): number {
+  if (cachedFdSoftLimit === undefined) {
+    try {
+      let report = process.report?.getReport() as unknown as
+        | { userLimits?: { open_files?: { soft?: unknown } } }
+        | undefined;
+      let soft = report?.userLimits?.open_files?.soft;
+      // "unlimited" comes through as a string; absent on Windows.
+      cachedFdSoftLimit =
+        typeof soft === "number" && soft > 0 ? soft : Infinity;
+    } catch {
+      cachedFdSoftLimit = Infinity;
+    }
+  }
+  return cachedFdSoftLimit;
+}
 
 // pnpm derives its download concurrency from the CPU count and clamps it;
 // same mechanism here, with smaller numbers because registry requests are
 // heavier than tarball fetches. A 1-CPU container lands on the floor, which
 // replaces the old `GITHUB_ENV` brand check with an actual constraint.
-export function deriveRequestBudget(cpus: number): number {
-  return Math.min(MAX_REQUEST_BUDGET, Math.max(MIN_REQUEST_BUDGET, cpus * 2));
+// The fd soft limit caps the result separately: CPUs say nothing about
+// EMFILE, and a many-core box with a low `ulimit -n` must not get the full
+// budget.
+export function deriveRequestBudget(cpus: number, fdLimit = Infinity): number {
+  let cpuBudget = Math.min(
+    MAX_REQUEST_BUDGET,
+    Math.max(MIN_REQUEST_BUDGET, cpus * 2),
+  );
+  let fdBudget = Math.max(1, Math.floor(fdLimit / FDS_PER_REQUEST));
+  return Math.min(cpuBudget, fdBudget);
 }
 
 let warnedInvalidEnv = false;
@@ -44,7 +78,7 @@ export function requestBudget(explicit?: number): number {
       );
     }
   }
-  return deriveRequestBudget(os.availableParallelism());
+  return deriveRequestBudget(os.availableParallelism(), fdSoftLimit());
 }
 
 // How many packages may install at once. An explicit per-package thread count
@@ -65,11 +99,70 @@ export function fileThreadsPerPackage(
   return Math.max(1, Math.min(MAX_FILE_THREADS, Math.floor(budget / packages)));
 }
 
+// The failures worth a retry: connection-level fetch errors and fd
+// exhaustion, where the cause is usually the aggregate concurrency rather
+// than the one request that lost. A registry answer ("Package not found") is
+// never transient. Checked against the whole cause chain, because undici
+// reports every network failure as a bare "fetch failed" TypeError with the
+// syscall error nested under `cause`.
+const TRANSIENT_ERROR_PATTERN =
+  /fetch failed|failed to fetch|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|EMFILE|ENFILE|EAI_AGAIN|UND_ERR_|socket hang up|other side closed|network socket disconnected/i;
+
+export function isTransientNetworkError(err: unknown, depth = 0): boolean {
+  if (err == null || depth > 5) {
+    return false;
+  }
+  if (typeof err === "string") {
+    return TRANSIENT_ERROR_PATTERN.test(err);
+  }
+  if (typeof err !== "object") {
+    return false;
+  }
+  let e = err as {
+    message?: unknown;
+    code?: unknown;
+    cause?: unknown;
+    errors?: unknown;
+  };
+  // Strings only: the agent's AgentError carries an ErrorCode *object* in
+  // `code` whose toString() can itself throw, so nothing here may stringify
+  // a non-string property.
+  try {
+    let text =
+      (typeof e.message === "string" ? e.message : "") +
+      " " +
+      (typeof e.code === "string" ? e.code : "");
+    if (TRANSIENT_ERROR_PATTERN.test(text)) {
+      return true;
+    }
+    // AggregateError, and ncp's array-of-errors rejections
+    if (
+      Array.isArray(e.errors) &&
+      e.errors.some((inner) => isTransientNetworkError(inner, depth + 1))
+    ) {
+      return true;
+    }
+    return isTransientNetworkError(e.cause, depth + 1);
+  } catch {
+    // a throwing getter is not a network error
+    return false;
+  }
+}
+
+function errorText(err: unknown): string {
+  let text = err instanceof Error ? err.message : String(err);
+  return text.split("\n")[0] ?? text;
+}
+
 // One install run. The top-level call decides `threads`; transitive levels
 // inherit it because they cannot see how wide the pool above them is.
+// `transientErrors` collects what individual package installs swallowed —
+// they report failure as `false`, so this is the only way the run can tell
+// a dead network from a package that does not exist.
 export type InstallScope = {
   threads: number;
   inFlight: Map<string, Promise<boolean>>;
+  transientErrors: string[];
 };
 
 const scopeStorage = new AsyncLocalStorage<InstallScope>();
@@ -79,7 +172,46 @@ export function getInstallScope(): InstallScope | undefined {
 }
 
 export function createInstallScope(threads: number): InstallScope {
-  return { threads, inFlight: new Map() };
+  return { threads, inFlight: new Map(), transientErrors: [] };
+}
+
+export function noteTransientNetworkError(err: unknown): void {
+  let scope = getInstallScope();
+  if (scope && isTransientNetworkError(err)) {
+    scope.transientErrors.push(errorText(err));
+  }
+}
+
+// Attempts an install run may make before giving up: the initial one and the
+// retries after it.
+export const MAX_INSTALL_ATTEMPTS = 3;
+
+// Whether a failed attempt earned a retry, and the budget to retry with.
+// Only transient failures qualify — noted by a package install or thrown
+// through the pool. The budget halves so an environment that cannot sustain
+// the concurrency degrades to a slower install instead of a broken one;
+// per-request retries cannot do that, because the other requests are still
+// holding the same ceiling. Returns undefined when the run should fail.
+export function nextRetryBudget(
+  scope: InstallScope,
+  thrown: unknown,
+  attempt: number,
+  budget: number,
+): number | undefined {
+  let transient =
+    scope.transientErrors[0] ??
+    (thrown !== undefined && isTransientNetworkError(thrown)
+      ? errorText(thrown)
+      : undefined);
+  if (transient === undefined || attempt >= MAX_INSTALL_ATTEMPTS) {
+    return undefined;
+  }
+  let next = Math.max(1, Math.floor(budget / 2));
+  console.warn(
+    chalk.yellow("Warning: ") +
+      `network error (${transient}); retrying with concurrency ${next} (attempt ${attempt + 1}/${MAX_INSTALL_ATTEMPTS})`,
+  );
+  return next;
 }
 
 export function runInInstallScope<T>(

--- a/cli/commands/install/install-deps.ts
+++ b/cli/commands/install/install-deps.ts
@@ -7,6 +7,7 @@ import {
   dedupeInstall,
   fileThreadsPerPackage,
   getInstallScope,
+  nextRetryBudget,
   packageConcurrency,
   requestBudget,
   runInInstallScope,
@@ -45,48 +46,76 @@ export async function installDeps(
   // recursion below carries one along.
   visitedLocalDeps: Set<string> = new Set(),
 ): Promise<boolean> {
+  let installLevel = async (
+    poolSize: number,
+    depThreads: number,
+    visited: Set<string>,
+  ): Promise<boolean> => {
+    let ok = true;
+
+    // A failed dependency does not abort the rest, same as the sequential loop
+    // this replaced — every package gets its own error message.
+    let install = async (dep: Dependency) => {
+      let run = () =>
+        installDep(
+          dep,
+          { verbose, silent, threads: depThreads, ignoreTransitive },
+          parentPkgPath,
+          visited,
+        );
+      // Local deps stay outside the dedupe map: their cycle guard lives inside
+      // installLocalDep, and awaiting a pending promise of your own ancestor
+      // would turn a manifest cycle into a deadlock.
+      let res = dep.path
+        ? await run()
+        : await dedupeInstall(depKey(dep, ignoreTransitive), run);
+      if (!res) {
+        ok = false;
+      }
+    };
+
+    await parallel(poolSize, deps, install);
+    return ok;
+  };
+
   let scope = getInstallScope();
-  let poolSize: number;
-  let depThreads: number;
   if (scope) {
     // Transitive levels install one package at a time: every branch of the
     // graph is then a single chain, so the top-level pool alone bounds how
     // many packages are in flight however deep the graph goes.
-    poolSize = 1;
-    depThreads = threads ?? scope.threads;
-  } else {
-    let budget = requestBudget(concurrency);
-    poolSize = packageConcurrency(deps.length, budget, threads);
-    depThreads = threads ?? fileThreadsPerPackage(poolSize, budget);
+    return installLevel(1, threads ?? scope.threads, visitedLocalDeps);
   }
 
-  let ok = true;
-
-  // A failed dependency does not abort the rest, same as the sequential loop
-  // this replaced — every package gets its own error message.
-  let install = async (dep: Dependency) => {
-    let run = () =>
-      installDep(
-        dep,
-        { verbose, silent, threads: depThreads, ignoreTransitive },
-        parentPkgPath,
-        visitedLocalDeps,
+  // The top level owns the retry: a transient network failure (connection
+  // reset, fd exhaustion) is retried with the budget halved, so already
+  // downloaded packages come from the cache and only the failures rerun.
+  let budget = requestBudget(concurrency);
+  for (let attempt = 1; ; attempt++) {
+    let poolSize = packageConcurrency(deps.length, budget, threads);
+    let depThreads = threads ?? fileThreadsPerPackage(poolSize, budget);
+    let attemptScope = createInstallScope(depThreads);
+    let ok = false;
+    let thrown: unknown = undefined;
+    try {
+      // A fresh visited-set per attempt: an already visited local dep is
+      // skipped entirely, which would hide its failed registry deps from
+      // the retry.
+      ok = await runInInstallScope(attemptScope, () =>
+        installLevel(poolSize, depThreads, new Set(visitedLocalDeps)),
       );
-    // Local deps stay outside the dedupe map: their cycle guard lives inside
-    // installLocalDep, and awaiting a pending promise of your own ancestor
-    // would turn a manifest cycle into a deadlock.
-    let res = dep.path
-      ? await run()
-      : await dedupeInstall(depKey(dep, ignoreTransitive), run);
-    if (!res) {
-      ok = false;
+    } catch (err) {
+      thrown = err;
     }
-  };
-
-  let run = () => parallel(poolSize, deps, install);
-  await (scope
-    ? run()
-    : runInInstallScope(createInstallScope(depThreads), run));
-
-  return ok;
+    if (ok) {
+      return true;
+    }
+    let retryBudget = nextRetryBudget(attemptScope, thrown, attempt, budget);
+    if (retryBudget === undefined) {
+      if (thrown !== undefined) {
+        throw thrown;
+      }
+      return false;
+    }
+    budget = retryBudget;
+  }
 }

--- a/cli/commands/install/install-from-github.ts
+++ b/cli/commands/install/install-from-github.ts
@@ -26,6 +26,7 @@ import {
   readLockedGithubDep,
   recordGithubDep,
 } from "../../integrity.js";
+import { noteTransientNetworkError } from "./install-concurrency.js";
 
 export const downloadFromGithub = async (
   repo: string,
@@ -200,6 +201,7 @@ export const installFromGithub = async (
         recordGithubDep(name, { resolved, hash });
       }
     } catch (err) {
+      noteTransientNetworkError(err);
       rmSync(stagingDir, { recursive: true, force: true });
       // The commit came from the lock, so a failed fetch of it is worth naming:
       // a force-push or a deleted branch can garbage-collect it upstream.

--- a/cli/commands/install/install-mops-dep.ts
+++ b/cli/commands/install/install-mops-dep.ts
@@ -21,7 +21,10 @@ import {
   getPackageFilesInfo,
 } from "../../api/downloadPackageFiles.js";
 import { installDeps } from "./install-deps.js";
-import { fileThreadsPerPackage } from "./install-concurrency.js";
+import {
+  fileThreadsPerPackage,
+  noteTransientNetworkError,
+} from "./install-concurrency.js";
 import { getDepName } from "../../helpers/get-dep-name.js";
 import { verifyDownloadedPackageFiles } from "../../integrity.js";
 
@@ -140,8 +143,10 @@ export async function installMopsDep(
       process.on("SIGINT", onSigInt);
 
       try {
+        // A halved-budget retry after EMFILE must lower write pressure too,
+        // so the pool follows the package's thread share down.
         await parallel(
-          FS_WRITE_CONCURRENCY,
+          Math.min(FS_WRITE_CONCURRENCY, threads * 4),
           Array.from(filesData.entries()),
           async ([filePath, data]) => {
             await fs.promises.mkdir(
@@ -156,6 +161,7 @@ export async function installMopsDep(
         );
         commitStagingDir(stagingDir, cacheDir);
       } catch (err) {
+        noteTransientNetworkError(err);
         console.error(chalk.red("Error: ") + err);
         fs.rmSync(stagingDir, { recursive: true, force: true });
         return false;
@@ -163,6 +169,7 @@ export async function installMopsDep(
         process.off("SIGINT", onSigInt);
       }
     } catch (err) {
+      noteTransientNetworkError(err);
       console.error(chalk.red("Error: ") + err);
       return false;
     }

--- a/cli/commands/install/sync-local-cache.ts
+++ b/cli/commands/install/sync-local-cache.ts
@@ -11,7 +11,13 @@ import { parallel } from "../../parallel.js";
 import { resolvePackages } from "../../resolve-packages.js";
 import { installFromGithub } from "./install-from-github.js";
 import { installMopsDep } from "./install-mops-dep.js";
-import { fileThreadsPerPackage } from "./install-concurrency.js";
+import {
+  createInstallScope,
+  fileThreadsPerPackage,
+  nextRetryBudget,
+  requestBudget,
+  runInInstallScope,
+} from "./install-concurrency.js";
 
 // Each task is a recursive directory copy, so a graph-wide fan-out runs out
 // of file descriptors. On the repair path below a task also downloads, hence
@@ -25,51 +31,74 @@ export async function syncLocalCache({ verbose = false } = {}): Promise<
 
   let resolvedPackages = await resolvePackages();
   let rootDir = getRootDir();
-  let repairThreads = fileThreadsPerPackage(COPY_CONCURRENCY);
 
   verbose && console.log("Syncing local cache...");
 
+  // Survives retries: a package copied on a failed attempt is already in
+  // `.mops` on the next one, so its entry would be lost from the result.
   let installedDeps: Record<string, string> = {};
 
-  await parallel(
-    COPY_CONCURRENCY,
-    Object.entries(resolvedPackages),
-    async ([name, value]) => {
-      let depType = getDependencyType(value);
+  let sync = async (copyPool: number, repairThreads: number) => {
+    await parallel(
+      copyPool,
+      Object.entries(resolvedPackages),
+      async ([name, value]) => {
+        let depType = getDependencyType(value);
 
-      if (depType === "mops" || depType === "github") {
-        let cacheName = getDepCacheName(name, value);
-        let dest = path.join(rootDir, ".mops", cacheName);
+        if (depType === "mops" || depType === "github") {
+          let cacheName = getDepCacheName(name, value);
+          let dest = path.join(rootDir, ".mops", cacheName);
 
-        if (!fs.existsSync(dest)) {
-          if (depType === "mops") {
-            installedDeps[name] = value;
-          }
-          // a resolved package can be missing from the global cache
-          // (pruned cache, interrupted install) — restore it before copying
-          if (!isDepCached(cacheName)) {
-            let ok =
-              depType === "mops"
-                ? await installMopsDep(name, value, {
-                    silent: true,
-                    ignoreTransitive: true,
-                    threads: repairThreads,
-                  })
-                : await installFromGithub(name, value, { silent: true });
-            if (!ok) {
-              throw Error(
-                `Package ${name} = "${value}" is not in the cache and could not be downloaded`,
-              );
+          if (!fs.existsSync(dest)) {
+            if (depType === "mops") {
+              installedDeps[name] = value;
             }
+            // a resolved package can be missing from the global cache
+            // (pruned cache, interrupted install) — restore it before copying
+            if (!isDepCached(cacheName)) {
+              let ok =
+                depType === "mops"
+                  ? await installMopsDep(name, value, {
+                      silent: true,
+                      ignoreTransitive: true,
+                      threads: repairThreads,
+                    })
+                  : await installFromGithub(name, value, { silent: true });
+              if (!ok) {
+                throw Error(
+                  `Package ${name} = "${value}" is not in the cache and could not be downloaded`,
+                );
+              }
+            }
+            await copyCache(cacheName, dest);
           }
-          await copyCache(cacheName, dest);
         }
-      }
-    },
-  ).catch((err) => {
-    // ncp rejects with an array of errors
-    throw Array.isArray(err) ? err[0] : err;
-  });
+      },
+    ).catch((err) => {
+      // ncp rejects with an array of errors
+      throw Array.isArray(err) ? err[0] : err;
+    });
+  };
 
-  return installedDeps;
+  // Same self-healing as installDeps: a transient network or fd failure on
+  // the repair path retries with the budget halved instead of aborting.
+  let budget = requestBudget();
+  for (let attempt = 1; ; attempt++) {
+    let copyPool = Math.min(COPY_CONCURRENCY, budget);
+    // The scope carries transient errors out of the repair installs, which
+    // report failure as the thrown "could not be downloaded" above.
+    let scope = createInstallScope(fileThreadsPerPackage(copyPool, budget));
+    try {
+      await runInInstallScope(scope, () =>
+        sync(copyPool, fileThreadsPerPackage(copyPool, budget)),
+      );
+      return installedDeps;
+    } catch (err) {
+      let retryBudget = nextRetryBudget(scope, err, attempt, budget);
+      if (retryBudget === undefined) {
+        throw err;
+      }
+      budget = retryBudget;
+    }
+  }
 }

--- a/cli/tests/install-concurrency.test.ts
+++ b/cli/tests/install-concurrency.test.ts
@@ -1,9 +1,21 @@
-import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
 import os from "node:os";
 import process from "node:process";
 import {
+  createInstallScope,
   deriveRequestBudget,
+  fdSoftLimit,
   fileThreadsPerPackage,
+  isTransientNetworkError,
+  MAX_INSTALL_ATTEMPTS,
+  nextRetryBudget,
   packageConcurrency,
   requestBudget,
 } from "../commands/install/install-concurrency";
@@ -16,6 +28,149 @@ describe("deriveRequestBudget", () => {
     expect(deriveRequestBudget(4)).toBe(8);
     expect(deriveRequestBudget(8)).toBe(16);
     expect(deriveRequestBudget(64)).toBe(16);
+  });
+
+  test("a low fd soft limit caps the budget below the CPU-derived floor", () => {
+    // macOS's default 256 and anything above it change nothing
+    expect(deriveRequestBudget(8, 256)).toBe(16);
+    expect(deriveRequestBudget(8, 1048576)).toBe(16);
+    // a constrained ulimit -n bites regardless of core count
+    expect(deriveRequestBudget(64, 128)).toBe(8);
+    expect(deriveRequestBudget(64, 64)).toBe(4);
+    expect(deriveRequestBudget(64, 32)).toBe(2);
+    expect(deriveRequestBudget(64, 20)).toBe(1);
+    // the CPU clamp still applies when fds are plentiful
+    expect(deriveRequestBudget(1, 1048576)).toBe(4);
+  });
+
+  test("fdSoftLimit reports a positive number or Infinity", () => {
+    let limit = fdSoftLimit();
+    expect(limit).toBeGreaterThan(0);
+    expect(fdSoftLimit()).toBe(limit);
+  });
+});
+
+describe("isTransientNetworkError", () => {
+  test("matches the connection-level failure modes", () => {
+    expect(isTransientNetworkError(new TypeError("fetch failed"))).toBe(true);
+    expect(
+      isTransientNetworkError(
+        Object.assign(new Error("connect ECONNRESET 1.2.3.4:443"), {
+          code: "ECONNRESET",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientNetworkError(
+        new Error("EMFILE: too many open files, open 'lib.mo'"),
+      ),
+    ).toBe(true);
+    expect(isTransientNetworkError("socket hang up")).toBe(true);
+  });
+
+  test("walks the cause chain undici buries syscall errors in", () => {
+    let syscall = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    expect(
+      isTransientNetworkError(
+        new TypeError("request failed", { cause: syscall }),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientNetworkError(new AggregateError([syscall], "all failed")),
+    ).toBe(true);
+  });
+
+  test("rejects registry answers and unrelated errors", () => {
+    expect(isTransientNetworkError("Package not found")).toBe(false);
+    expect(isTransientNetworkError(new Error("integrity check failed"))).toBe(
+      false,
+    );
+    expect(isTransientNetworkError(undefined)).toBe(false);
+    expect(isTransientNetworkError(null)).toBe(false);
+    expect(isTransientNetworkError(42)).toBe(false);
+  });
+
+  test("an agent error with an object code whose toString throws is classified by message", () => {
+    // @icp-sdk/core's AgentError: message carries the text, `code` is an
+    // ErrorCode object whose toString() can throw (seen live against a dead
+    // registry endpoint)
+    let code = {
+      toString() {
+        throw new Error("Uint8Array expected");
+      },
+    };
+    let agentError = Object.assign(
+      new Error("Failed to fetch HTTP request: TypeError: fetch failed"),
+      { code },
+    );
+    expect(isTransientNetworkError(agentError)).toBe(true);
+    expect(
+      isTransientNetworkError(
+        Object.assign(new Error("reject code 4"), { code }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a self-referential cause chain terminates", () => {
+    let err: any = new Error("boring");
+    err.cause = err;
+    expect(isTransientNetworkError(err)).toBe(false);
+  });
+});
+
+describe("nextRetryBudget", () => {
+  let warn: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  test("halves the budget when the scope noted a transient error", () => {
+    let scope = createInstallScope(8);
+    scope.transientErrors.push("fetch failed");
+    expect(nextRetryBudget(scope, undefined, 1, 16)).toBe(8);
+    expect(nextRetryBudget(scope, undefined, 2, 8)).toBe(4);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(String(warn.mock.calls[0]?.[0])).toMatch(/fetch failed/);
+    expect(String(warn.mock.calls[0]?.[0])).toMatch(/concurrency 8/);
+  });
+
+  test("a transient thrown error qualifies without a scope note", () => {
+    expect(
+      nextRetryBudget(
+        createInstallScope(8),
+        new TypeError("fetch failed"),
+        1,
+        4,
+      ),
+    ).toBe(2);
+  });
+
+  test("permanent failures and exhausted attempts do not retry", () => {
+    let noted = createInstallScope(8);
+    noted.transientErrors.push("ECONNRESET");
+    expect(nextRetryBudget(createInstallScope(8), undefined, 1, 16)).toBe(
+      undefined,
+    );
+    expect(
+      nextRetryBudget(createInstallScope(8), new Error("boom"), 1, 16),
+    ).toBe(undefined);
+    expect(nextRetryBudget(noted, undefined, MAX_INSTALL_ATTEMPTS, 16)).toBe(
+      undefined,
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("the budget floors at 1", () => {
+    let scope = createInstallScope(1);
+    scope.transientErrors.push("EMFILE");
+    expect(nextRetryBudget(scope, undefined, 1, 1)).toBe(1);
   });
 });
 
@@ -35,9 +190,9 @@ describe("requestBudget", () => {
     }
   });
 
-  test("defaults derive from available parallelism", () => {
+  test("defaults derive from available parallelism and the fd limit", () => {
     expect(requestBudget()).toBe(
-      deriveRequestBudget(os.availableParallelism()),
+      deriveRequestBudget(os.availableParallelism(), fdSoftLimit()),
     );
   });
 

--- a/cli/tests/install-parallel.test.ts
+++ b/cli/tests/install-parallel.test.ts
@@ -138,6 +138,8 @@ describe("parallel install", () => {
       expect(result.stderr + result.stdout).toMatch(/nonexistent/);
       expect(result.stderr).not.toMatch(/UnhandledPromiseRejection/);
       expect(result.stderr).not.toMatch(/ERR_UNHANDLED_REJECTION/);
+      // a registry answer is a permanent failure — no transient-error retry
+      expect(result.stderr).not.toMatch(/retrying with concurrency/);
 
       // siblings that were in flight alongside the failure still committed
       // whole packages to the global cache
@@ -150,6 +152,37 @@ describe("parallel install", () => {
           entry.startsWith(".staging"),
         ),
       ).toEqual([]);
+    } finally {
+      rmSync(cacheHome, { recursive: true, force: true });
+    }
+  });
+
+  test("transient network failures retry with the concurrency halved", async () => {
+    // 127.0.0.1:9 refuses connections, so every registry request fails with
+    // undici's "fetch failed" — the transient case. No real network involved,
+    // which keeps this test alive during registry or GitHub incidents.
+    // `mops sources` rather than `mops install`: it installs the same way but
+    // performs no API compatibility check, which needs the same dead registry.
+    const cwd = await makeTempFixture("graph");
+    const cacheHome = await makeTempCacheHome();
+
+    try {
+      const result = await cli(["sources"], {
+        cwd,
+        env: {
+          CI: undefined,
+          XDG_CACHE_HOME: cacheHome,
+          MOPS_REGISTRY_HOST: "http://127.0.0.1:9",
+          MOPS_CONCURRENCY: "16",
+        },
+      });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toMatch(
+        /retrying with concurrency 8 \(attempt 2\/3\)/,
+      );
+      expect(result.stderr).toMatch(
+        /retrying with concurrency 4 \(attempt 3\/3\)/,
+      );
     } finally {
       rmSync(cacheHome, { recursive: true, force: true });
     }

--- a/cli/tests/install-retry.test.ts
+++ b/cli/tests/install-retry.test.ts
@@ -1,0 +1,105 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import process from "node:process";
+import { Dependency } from "../types";
+
+// The retry loop must be observed through the real installDeps, so only the
+// per-package leaf is mocked. `threads` handed to it is the visible trace of
+// the budget: with one dep and a budget of 16 the attempts should descend
+// 12 -> 8 -> 4.
+jest.unstable_mockModule("../commands/install/install-dep", () => ({
+  installDep: jest.fn(),
+}));
+
+const { installDep } = await import("../commands/install/install-dep");
+const { installDeps } = await import("../commands/install/install-deps");
+const { noteTransientNetworkError } =
+  await import("../commands/install/install-concurrency");
+
+const installDepMock = installDep as jest.Mock<typeof installDep>;
+
+const dep: Dependency = { name: "core", version: "1.0.0" };
+
+const threadsPassed = () =>
+  installDepMock.mock.calls.map((call) => (call[1] as any)?.threads);
+
+describe("installDeps transient-failure retry", () => {
+  let savedEnv: string | undefined;
+  let warn: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    savedEnv = process.env.MOPS_CONCURRENCY;
+    // pin the budget so the expected thread counts do not depend on the host
+    process.env.MOPS_CONCURRENCY = "16";
+    installDepMock.mockReset();
+    warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.MOPS_CONCURRENCY;
+    } else {
+      process.env.MOPS_CONCURRENCY = savedEnv;
+    }
+    warn.mockRestore();
+  });
+
+  test("a noted transient failure retries with the budget halved, then succeeds", async () => {
+    let failures = 2;
+    installDepMock.mockImplementation(async () => {
+      if (failures-- > 0) {
+        noteTransientNetworkError(new TypeError("fetch failed"));
+        return false;
+      }
+      return true;
+    });
+
+    await expect(installDeps([dep], { silent: true })).resolves.toBe(true);
+    expect(threadsPassed()).toEqual([12, 8, 4]);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(String(warn.mock.calls[0]?.[0])).toMatch(/fetch failed/);
+  });
+
+  test("a permanent failure is not retried", async () => {
+    installDepMock.mockImplementation(async () => false);
+
+    await expect(installDeps([dep], { silent: true })).resolves.toBe(false);
+    expect(installDepMock).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("attempts are exhausted after two retries", async () => {
+    installDepMock.mockImplementation(async () => {
+      noteTransientNetworkError(
+        Object.assign(new Error("connect ECONNRESET"), { code: "ECONNRESET" }),
+      );
+      return false;
+    });
+
+    await expect(installDeps([dep], { silent: true })).resolves.toBe(false);
+    expect(installDepMock).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  test("a thrown transient error is retried too", async () => {
+    installDepMock
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(true);
+
+    await expect(installDeps([dep], { silent: true })).resolves.toBe(true);
+    expect(installDepMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a thrown permanent error propagates unretried", async () => {
+    installDepMock.mockRejectedValue(new Error("boom"));
+
+    await expect(installDeps([dep], { silent: true })).rejects.toThrow("boom");
+    expect(installDepMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cli/tests/sync-cache-retry.test.ts
+++ b/cli/tests/sync-cache-retry.test.ts
@@ -1,0 +1,85 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+// syncLocalCache's repair path reports a transient download failure as a
+// thrown "could not be downloaded" — the retry must see through that via the
+// scope note, not the thrown message.
+jest.unstable_mockModule("../resolve-packages", () => ({
+  resolvePackages: jest.fn(async () => ({ core: "1.0.0" })),
+}));
+jest.unstable_mockModule("../mops", () => ({
+  getDependencyType: () => "mops",
+  getRootDir: () => rootDir,
+}));
+jest.unstable_mockModule("../cache", () => ({
+  getDepCacheName: (name: string, version: string) => `${name}@${version}`,
+  isDepCached: () => false,
+  sweepStaleStagingDirs: () => {},
+  copyCache: jest.fn(async () => {}),
+}));
+jest.unstable_mockModule("../commands/install/install-mops-dep", () => ({
+  installMopsDep: jest.fn(),
+}));
+jest.unstable_mockModule("../commands/install/install-from-github", () => ({
+  installFromGithub: jest.fn(),
+}));
+
+const { installMopsDep } = await import("../commands/install/install-mops-dep");
+const { copyCache } = await import("../cache");
+const { syncLocalCache } = await import("../commands/install/sync-local-cache");
+const { noteTransientNetworkError } =
+  await import("../commands/install/install-concurrency");
+
+const installMopsDepMock = installMopsDep as jest.Mock<typeof installMopsDep>;
+
+let rootDir: string;
+
+describe("syncLocalCache transient-failure retry", () => {
+  let warn: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(path.join(os.tmpdir(), "mops-sync-retry-"));
+    process.env.MOPS_CONCURRENCY = "16";
+    installMopsDepMock.mockReset();
+    warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete process.env.MOPS_CONCURRENCY;
+    rmSync(rootDir, { recursive: true, force: true });
+    warn.mockRestore();
+  });
+
+  test("a transient repair failure retries and then succeeds", async () => {
+    installMopsDepMock
+      .mockImplementationOnce(async () => {
+        noteTransientNetworkError(new TypeError("fetch failed"));
+        return false;
+      })
+      .mockResolvedValueOnce(true);
+
+    await expect(syncLocalCache()).resolves.toEqual({ core: "1.0.0" });
+    expect(installMopsDepMock).toHaveBeenCalledTimes(2);
+    expect(copyCache).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toMatch(/retrying/);
+  });
+
+  test("a permanent repair failure throws without a retry", async () => {
+    installMopsDepMock.mockResolvedValue(false);
+
+    await expect(syncLocalCache()).rejects.toThrow(/could not be downloaded/);
+    expect(installMopsDepMock).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/docs/docs/cli/1-deps/02-mops-install.md
+++ b/docs/docs/cli/1-deps/02-mops-install.md
@@ -62,7 +62,7 @@ mops install            # dev: keep the lockfile in sync
 
 ### `--concurrency <n>`
 
-Maximum number of simultaneous registry requests (an integer ≥ 1). The default is derived from the CPU count (2 × cores, clamped to 4–16), so a small container gets a budget it can survive and a big machine saturates the registry.
+Maximum number of simultaneous registry requests (an integer ≥ 1). The default is derived from the CPU count (2 × cores, clamped to 4–16) and capped by the file-descriptor soft limit (`ulimit -n`), so a small container gets a budget it can survive and a big machine saturates the registry.
 
 The same limit can be set with the [`MOPS_CONCURRENCY`](../7-misc/06-environment-variables.md#mops_concurrency) environment variable, which also covers every other command that installs packages (`mops build`, `mops test`, `mops sources`, ...) and works where the command line cannot be edited — Docker builds, prebuilt CI images. The flag wins over the environment variable.
 
@@ -70,6 +70,8 @@ The same limit can be set with the [`MOPS_CONCURRENCY`](../7-misc/06-environment
 mops install --concurrency 4
 MOPS_CONCURRENCY=1 mops build   # fully serial downloads
 ```
+
+When an install hits a transient network or file-descriptor error (`fetch failed`, `ECONNRESET`, `EMFILE`, ...), it retries up to twice with the concurrency halved — already downloaded packages come from the cache, so only the failures are re-fetched. The halving applies even when the limit was set explicitly.
 
 ### `--no-toolchain`
 

--- a/docs/docs/cli/7-misc/06-environment-variables.md
+++ b/docs/docs/cli/7-misc/06-environment-variables.md
@@ -30,7 +30,7 @@ mops install
 
 Cap the number of simultaneous registry requests during package installs (an integer ≥ 1). Applies to every command that installs packages — `mops install`, `mops add`, `mops build`, `mops test`, `mops sources`, and so on. Equivalent to [`mops install --concurrency <n>`](../1-deps/02-mops-install.md#--concurrency-n); the flag wins when both are set.
 
-The default is derived from the CPU count (2 × cores, clamped to 4–16). Set a low value in constrained environments — a 1-CPU container, an egress proxy capping concurrent connections, a low file-descriptor limit:
+The default is derived from the CPU count (2 × cores, clamped to 4–16) and capped by the file-descriptor soft limit. Transient network failures retry on their own with the concurrency halved, but a low explicit value still helps environments that are constrained in ways mops cannot see — an egress proxy capping concurrent connections, for example:
 
 ```bash
 export MOPS_CONCURRENCY=2


### PR DESCRIPTION
A single transient network failure aborted the whole install: nothing on the install path handled `fetch failed`, `ECONNRESET` or `EMFILE`, so one dropped connection in a container turned into "mops is broken". The install pool now retries up to twice with the request budget halved, so a constrained environment degrades to a slower install instead of a failed one. Finishes the resilience half of item 31 in [#723](https://github.com/caffeinelabs/mops/issues/723); follow-up to [#745](https://github.com/caffeinelabs/mops/pull/745).

Per-request retry could not fix this class of failure: when the cause is aggregate concurrency, retrying one request while the others still hold the same ceiling hits the same wall — which is why the IC agent's built-in per-request backoff never covered it. The budget itself has to come down, and only the pool layer can do that.

**Before** (any transient error, cold cache):

```
Error: TransportError (Transport): Failed to fetch HTTP request: TypeError: fetch failed
Error: Package core@1.0.0 is not in the cache and could not be downloaded
```

**After**:

```
Error: TransportError (Transport): Failed to fetch HTTP request: TypeError: fetch failed
Warning: network error (Failed to fetch HTTP request: TypeError: fetch failed); retrying with concurrency 8 (attempt 2/3)
Packages installed
```

## How it works

- Package installs report failure as `false` with the error swallowed, so the install scope now carries a `transientErrors` note that `installMopsDep` / `installFromGithub` record at their existing catch sites. The top-level `installDeps` run and `syncLocalCache`'s repair path check it (plus errors thrown through the pool) and retry with the budget halved; packages that already landed come from the cache, so only failures re-download. Registry answers ("Package not found") never retry — the existing missing-dep test now asserts that.
- Classification walks `cause` chains and `AggregateError`s, because undici reports every network failure as a bare `fetch failed` `TypeError` with the syscall error nested inside. It also never stringifies non-string properties: `@icp-sdk/core`'s `AgentError.code` is an `ErrorCode` *object* whose own `toString()` can throw (hit live against a dead registry endpoint; covered by a regression test).
- The default request budget is now `min(cpu budget, fd soft limit / 16)`. `os.availableParallelism()` is the wrong signal for `EMFILE` — a many-core machine with a low `ulimit -n` still got the full 16. The limit is read once from `process.report` (the only way node exposes it); macOS's default 256 and typical Linux limits leave the budget unchanged. The per-package fs write pool now follows the thread share down too, so a halved budget also lowers write pressure after `EMFILE`.

## What is unchanged

- The resolver's fetch-on-miss (`resolve-packages.ts`) stays single-request and sequential — aggregate concurrency cannot be its cause, and the agent's per-request retry already covers it.
- GitHub archive downloads get retried as pool members here, but fetching `codeload` directly and per-download retry remain [#723](https://github.com/caffeinelabs/mops/issues/723) item 39.
- HTTP/2 connection reuse and overlapping `checkApiCompatibility()` with the install (the rest of item 31) come separately.

The end-to-end test drives `mops sources` against `127.0.0.1:9` (connection refused, no real network), so it stays deterministic during registry or GitHub incidents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)