### PR TITLE
chore(cli): recommend pocket-ic 15.0.0 instead of 12.0.0

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -22,7 +22,7 @@ Opinionated guide for Motoko projects. Covers project config, dependency managem
 [toolchain]
 moc = "1.7.0"
 lintoko = "0.10.0"
-pocket-ic = "12.0.0"  # only if you have replica tests / benchmarks
+pocket-ic = "15.0.0"  # only if you have replica tests / benchmarks
 
 [dependencies]
 core = "2.5.0"
@@ -160,7 +160,7 @@ mops generate candid backend -o <path>   # single canister, ad-hoc path
 mops toolchain use moc 1.7.0         # pin specific version
 mops toolchain use moc latest        # pin latest version (non-interactive)
 mops toolchain use lintoko 0.10.0    # pin specific version
-mops toolchain use pocket-ic 12.0.0  # pin for replica tests / benchmarks (pin a specific version; `latest` may resolve to one the vendored `@dfinity/pic` client doesn't support)
+mops toolchain use pocket-ic 15.0.0  # pin for replica tests / benchmarks (pin a specific version; `latest` may resolve to one the vendored `@dfinity/pic` client doesn't support)
 mops toolchain use wasm-opt 131      # Binaryen for [optimize] (or `latest`)
 mops toolchain update moc            # update to latest (requires existing [toolchain] entry)
 mops toolchain update                # update all tools to latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,12 +23,12 @@ Some `mops` commands prompt for input and hang in non-TTY environments (CI, agen
 | `mops init` | `mops init --yes` |
 | `mops bump` | `mops bump <major\|minor\|patch>` |
 | `mops template` | `mops template <name>` (see `mops template --help` for names) |
-| `mops toolchain use <tool>` | `mops toolchain use <tool> <version>` (e.g. `pocket-ic 12.0.0`). `latest` works but may resolve to a version incompatible with the shipped client. |
+| `mops toolchain use <tool>` | `mops toolchain use <tool> <version>` (e.g. `pocket-ic 15.0.0`). `latest` works but may resolve to a version incompatible with the shipped client. |
 | `mops owner add\|rm <principal>` | `mops owner add\|rm <principal> --yes` |
 | `mops maintainer add\|rm <principal>` | `mops maintainer add\|rm <principal> --yes` |
 | `mops publish` (missing recommended `[package]` field, `CI` env unset) | Fill the field in `[package]`, or run with `CI=1` |
 
-When adding a new command or option, prefer non-interactive (accept the value as an argument or flag). Reserve prompts for purely human-facing flows like `mops init`, and at any deprecation/missing-arg site recommend the non-interactive command verbatim (e.g. ``mops toolchain use pocket-ic 12.0.0``, not ``mops toolchain use pocket-ic``).
+When adding a new command or option, prefer non-interactive (accept the value as an argument or flag). Reserve prompts for purely human-facing flows like `mops init`, and at any deprecation/missing-arg site recommend the non-interactive command verbatim (e.g. ``mops toolchain use pocket-ic 15.0.0``, not ``mops toolchain use pocket-ic``).
 
 ## What this repo is
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
+- All deprecation warnings, error hints, and doc examples that suggested `mops toolchain use pocket-ic 12.0.0` now suggest `15.0.0`, the current PocketIC release.
 
 ## 2.22.0
 - Updating the lock after a dependency change no longer refetches file hashes for the whole graph from the registry: hashes of packages already in the lock are carried over (published versions are immutable), and only packages new to the lock are queried. `mops remove` now updates the lock without any registry queries. Explicit `mops install --lock update` still refreshes every hash from the registry, so it remains the recovery command for a lock with corrupt hashes.

--- a/cli/commands/build.ts
+++ b/cli/commands/build.ts
@@ -65,7 +65,7 @@ export async function build(
     const pocketIcVersion = config.toolchain?.["pocket-ic"];
     if (!pocketIcVersion) {
       cliError(
-        "PocketIC deployment check requires `pocket-ic` in `[toolchain]`. Run `mops toolchain use pocket-ic 12.0.0` to pin it.",
+        "PocketIC deployment check requires `pocket-ic` in `[toolchain]`. Run `mops toolchain use pocket-ic 15.0.0` to pin it.",
       );
     }
     try {

--- a/cli/helpers/deprecate-dfx-replica.ts
+++ b/cli/helpers/deprecate-dfx-replica.ts
@@ -26,7 +26,7 @@ export function warnIfDfxReplica(
         : "Using `dfx` replica because no `pocket-ic` version is set in `[toolchain]`. The `dfx` replica is deprecated and will be removed in a future release.";
   console.log(
     chalk.yellow(
-      `${lead}\nRun \`mops toolchain use pocket-ic 12.0.0\` to pin a PocketIC version and silence this warning.`,
+      `${lead}\nRun \`mops toolchain use pocket-ic 15.0.0\` to pin a PocketIC version and silence this warning.`,
     ),
   );
 }

--- a/cli/helpers/deprecate-legacy-pocket-ic.ts
+++ b/cli/helpers/deprecate-legacy-pocket-ic.ts
@@ -13,7 +13,7 @@ export function warnLegacyPocketIc(version: string): void {
   console.log(
     chalk.yellow(
       `\`pocket-ic\` is pinned to ${version} in \`[toolchain]\`. Support for \`pocket-ic\` below 9.0.0 is deprecated and will be removed in mops v3.\n` +
-        "Run `mops toolchain use pocket-ic 12.0.0` to move to a supported version and silence this warning.",
+        "Run `mops toolchain use pocket-ic 15.0.0` to move to a supported version and silence this warning.",
     ),
   );
 }

--- a/cli/helpers/pocket-ic-startup.ts
+++ b/cli/helpers/pocket-ic-startup.ts
@@ -12,14 +12,14 @@ export function assertDfinityClientSupportsPocketIc(
   if (!version || semver.valid(version) === null) {
     throw new Error(
       `PocketIC version ${JSON.stringify(version)} is invalid for deployment checks. ` +
-        "Use an exact semantic version. Run `mops toolchain use pocket-ic 12.0.0` to pin a supported version.",
+        "Use an exact semantic version. Run `mops toolchain use pocket-ic 15.0.0` to pin a supported version.",
     );
   }
   if (semver.lt(version, MIN_DFINITY_CLIENT_POCKET_IC_VERSION)) {
     throw new Error(
       `PocketIC ${version} is incompatible with deployment checks. ` +
         `\`mops build --check-deploy\` requires pocket-ic ${MIN_DFINITY_CLIENT_POCKET_IC_VERSION} or newer. ` +
-        "Run `mops toolchain use pocket-ic 12.0.0` to pin a supported version.",
+        "Run `mops toolchain use pocket-ic 15.0.0` to pin a supported version.",
     );
   }
 }

--- a/cli/tests/build.test.ts
+++ b/cli/tests/build.test.ts
@@ -383,7 +383,7 @@ describe("build", () => {
     try {
       const result = await cli(["build", "foo", "--check-deploy"], { cwd });
       expect(result.exitCode).toBe(1);
-      expect(result.stderr).toMatch("mops toolchain use pocket-ic 12.0.0");
+      expect(result.stderr).toMatch("mops toolchain use pocket-ic 15.0.0");
     } finally {
       cleanFixture(cwd);
     }

--- a/docs/docs/09-mops.toml.md
+++ b/docs/docs/09-mops.toml.md
@@ -63,7 +63,7 @@ See [toolchain management](./cli/5-toolchain/01-toolchain-overview.md) page for 
 | -------------------- | ------------------------------------------------ |
 | moc                  | Motoko compiler version (e.g. `1.0.0`) or file path (e.g. `./tools/moc`, `/usr/local/bin/moc`)   |
 | wasmtime             | WASM runtime version (e.g. `41.0.0`) or file path used to run [tests](./cli/4-dev/01-mops-test.md#--mode) in `wasi` mode   |
-| pocket-ic            | Local IC replica version (e.g. `12.0.0`) or file path used to run [benchmarks](./cli/4-dev/02-mops-bench.md#--replica). Versions below `9.0.0` are deprecated and will no longer be supported in mops v3   |
+| pocket-ic            | Local IC replica version (e.g. `15.0.0`) or file path used to run [benchmarks](./cli/4-dev/02-mops-bench.md#--replica). Versions below `9.0.0` are deprecated and will no longer be supported in mops v3   |
 | lintoko              | Linter version (e.g. `0.7.0`) or file path for Motoko linting   |
 | wasm-opt             | Binaryen version (e.g. `131`) or file path used for `[optimize]` post-build Wasm optimization   |
 

--- a/docs/docs/cli/4-dev/01-mops-test.md
+++ b/docs/docs/cli/4-dev/01-mops-test.md
@@ -75,7 +75,7 @@ Default `pocket-ic` if `pocket-ic` is specified in `mops.toml` in `[toolchain]` 
 
 Possible values:
 - `pocket-ic` - use [PocketIC](https://github.com/dfinity/pocketic) light replica via [pic.js](https://github.com/dfinity/pic-js). Recommended.
-- `dfx` - **deprecated**. Uses `dfx` local replica. Will be removed in a future release. Run `mops toolchain use pocket-ic 12.0.0` to pin a PocketIC version and `mops test` will use it directly.
+- `dfx` - **deprecated**. Uses `dfx` local replica. Will be removed in a future release. Run `mops toolchain use pocket-ic 15.0.0` to pin a PocketIC version and `mops test` will use it directly.
 
 :::info
 If you run `mops test --replica pocket-ic` AND `pocket-ic` is not specified in `mops.toml` in `[toolchain]` section, Mops will use pocket-ic replica that comes with dfx (`dfx start --pocketic`). This fallback path is also deprecated.

--- a/docs/docs/cli/4-dev/01-mops-watch.md
+++ b/docs/docs/cli/4-dev/01-mops-watch.md
@@ -56,7 +56,7 @@ mops watch --test
 ```
 
 :::info
-Replica tests use `pocket-ic` if it's pinned in `mops.toml` under `[toolchain]`, otherwise they fall back to the `dfx` replica, which is **deprecated** and will be removed in a future release. Run `mops toolchain use pocket-ic 12.0.0` to pin a PocketIC version and silence the warning.
+Replica tests use `pocket-ic` if it's pinned in `mops.toml` under `[toolchain]`, otherwise they fall back to the `dfx` replica, which is **deprecated** and will be removed in a future release. Run `mops toolchain use pocket-ic 15.0.0` to pin a PocketIC version and silence the warning.
 :::
 
 ### `--generate`

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -51,7 +51,7 @@ Default `pocket-ic` if `pocket-ic` is specified in `mops.toml` in `[toolchain]` 
 
 Possible values:
 - `pocket-ic` - use [PocketIC](https://github.com/dfinity/pocketic) light replica via [pic.js](https://github.com/dfinity/pic-js). Recommended.
-- `dfx` - **deprecated**. Uses `dfx` local replica. Will be removed in a future release. Run `mops toolchain use pocket-ic 12.0.0` to pin a PocketIC version and `mops bench` will use it directly.
+- `dfx` - **deprecated**. Uses `dfx` local replica. Will be removed in a future release. Run `mops toolchain use pocket-ic 15.0.0` to pin a PocketIC version and `mops bench` will use it directly.
 
 ### `--gc`
 

--- a/docs/docs/cli/4-dev/03-mops-build.md
+++ b/docs/docs/cli/4-dev/03-mops-build.md
@@ -127,7 +127,7 @@ PocketIC 9.0.0 or newer, or a local PocketIC binary path, must be pinned in
 `[toolchain]`. Mops cannot verify compatibility for a path pin.
 ```toml
 [toolchain]
-pocket-ic = "12.0.0"
+pocket-ic = "15.0.0"
 ```
 
 To check deployment with a non-default Wasm memory limit, configure the limit in

--- a/docs/docs/cli/5-toolchain/01-toolchain-overview.md
+++ b/docs/docs/cli/5-toolchain/01-toolchain-overview.md
@@ -24,7 +24,7 @@ You can use [`mops toolchain use`](./03-mops-toolchain-use.md) command to instal
 ```
 mops toolchain use moc 0.10.3
 mops toolchain use wasmtime 16.0.0
-mops toolchain use pocket-ic 12.0.0
+mops toolchain use pocket-ic 15.0.0
 mops toolchain use lintoko 0.7.0
 mops toolchain use wasm-opt 131
 ```
@@ -40,7 +40,7 @@ You can manually edit `mops.toml` file to specify exact versions of each tool.
 moc = "0.10.3"
 wasmtime = "16.0.0"
 lintoko = "0.7.0"
-pocket-ic = "12.0.0"
+pocket-ic = "15.0.0"
 wasm-opt = "131"
 ```
 


### PR DESCRIPTION
Every deprecation warning, error hint, and doc example that told users to `mops toolchain use pocket-ic 12.0.0` was pointing at a version that's no longer the current PocketIC release. 15.0.0 is now current and works fine with the vendored `@dfinity/pic` client (verified locally by running the CLI's replica test suite against it).

Updated `mops toolchain use pocket-ic 12.0.0` → `15.0.0` everywhere it appears as a recommendation: the `dfx`/legacy-pocket-ic deprecation warnings, the `--check-deploy` missing-pin error, the `mops.toml` example pins in the docs and `.agents/skills/mops-cli/SKILL.md`, and the matching test assertion in `build.test.ts`.

## What is unchanged

- `MIN_DFINITY_CLIENT_POCKET_IC_VERSION` (floor of `9.0.0`) is untouched — this only moves the *recommended* version, not the supported range.
- Test fixtures that pin an actual PocketIC version to run against (e.g. `cli/tests/pocket-ic/mops.toml`, `cli/tests/pocket-ic.test.ts`) are left at `12.0.0` since they're exercising a known-good pinned version, not surfacing a recommendation to users.
- `docs/versioned_docs/version-2.x/` is a frozen snapshot of the released 2.x docs and wasn't touched, per this repo's docs policy.