### PR TITLE
fix(cli): keep `.mo` check-stable baselines off the `--stable-baseline` fold

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fixed `mops check-stable` applying 2.23.0's stricter moc 1.12.0+ upgrade check to `.mo` baselines. 2.23.0 said the change was limited to canisters with `[migrations]` and a committed `.most` baseline, but a `.mo` baseline got it too once mops had compiled it to a scratch `.most` — so an upgrade a forgotten migration left incomplete flipped from a warning (`M0254`) to a failing `M0267`, and a previously green `mops check` / `mops check-stable` started failing. `.mo` baselines are back on the three-step path, as documented. Committed `.most` baselines are unaffected.
+
 ## 2.23.0
 - All deprecation warnings, error hints, and doc examples that suggested `mops toolchain use pocket-ic 12.0.0` now suggest `15.0.0`, the current PocketIC release.
 - On moc 1.12.0+, `mops check` and `mops check-stable` check upgrade compatibility faster and report it better for canisters with `[migrations]` and a committed `.most` baseline: compatibility errors now point at your source (`src/main.mo:3.1-11.2`) instead of `(unknown location)`, and a field the initial actor requires that no migration produces now fails as an `M0267` error rather than only warning (`M0254`) — a forgotten migration that previously slipped through as a warning will now fail the check. Older moc pins, canisters without `[migrations]`, and `.mo` baselines are unaffected.

--- a/cli/commands/check-stable.ts
+++ b/cli/commands/check-stable.ts
@@ -235,13 +235,15 @@ export function reportStableCheckOutcome(
   );
 }
 
-/** One `moc --check --stable-baseline` covering typecheck + upgrade compat. */
+/**
+ * One `moc --check --stable-baseline` covering typecheck + upgrade compat.
+ * `baselinePath` is always a committed `.most` — see `runStableCheck`.
+ */
 async function runFoldedStableCheck(params: {
   canisterMain: string;
   canisterName: string;
   mocPath: string;
   baselinePath: string;
-  baselineIsMostFile: boolean;
   sources: string[];
   globalMocArgs: string[];
   canisterArgs: string[];
@@ -278,7 +280,7 @@ async function runFoldedStableCheck(params: {
   reportStableCheckOutcome(params.canisterName, {
     migrations: params.migrations,
     oldMostPath: params.baselinePath,
-    baselineIsMostFile: params.baselineIsMostFile,
+    baselineIsMostFile: true,
     checkLimit: params.options.checkLimit,
     exitCode: result.exitCode,
     stderr: result.stderr,
@@ -305,14 +307,16 @@ export async function runStableCheck(
     cliError(`File not found: ${oldFile}`);
   }
 
-  // Fast path: .most baseline + moc 1.12.0+ → one --check, no scratch dir.
+  // Committed .most baseline + moc 1.12.0+ → one --check, no scratch dir.
+  // A .mo baseline keeps the 3-step path: the scratch .most compiled from it is
+  // only an approximation of what is deployed, and the folded check is stricter
+  // (a field no migration produces fails as M0267 rather than warning M0254).
   if (isOldMostFile && canUseStableBaselineCheck(canisterArgs)) {
     await runFoldedStableCheck({
       canisterMain,
       canisterName,
       mocPath,
       baselinePath: oldFile,
-      baselineIsMostFile: true,
       sources,
       globalMocArgs,
       canisterArgs,
@@ -338,22 +342,6 @@ export async function runStableCheck(
           canisterArgs,
           options,
         );
-
-    if (canUseStableBaselineCheck(canisterArgs)) {
-      await runFoldedStableCheck({
-        canisterMain,
-        canisterName,
-        mocPath,
-        baselinePath: oldMostPath,
-        baselineIsMostFile: isOldMostFile,
-        sources,
-        globalMocArgs,
-        canisterArgs,
-        migrations: params.migrations,
-        options,
-      });
-      return;
-    }
 
     const newMostPath = await generateStableTypes(
       mocPath,

--- a/cli/tests/check-stable.test.ts
+++ b/cli/tests/check-stable.test.ts
@@ -39,6 +39,20 @@ describe("check-stable", () => {
     expect(result.stdout).toMatch(/Stable compatibility check passed/);
   });
 
+  // Fixture pinned to moc 1.12.0 — EM, but a `.mo` baseline, so no fold. The
+  // scratch `.most` compiled from it is only an approximation of what is
+  // deployed; `d` is produced by no migration, which the folded check would
+  // reject as M0267 where `--stable-compatible` only warns (M0254).
+  test("moc 1.12+ EM keeps the 3-step path for a .mo baseline", async () => {
+    const cwd = path.join(import.meta.dirname, "check-stable/mo-baseline-em");
+    const result = await cli(["check-stable", "--verbose"], { cwd });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/--stable-compatible/);
+    expect(result.stdout).not.toMatch(/--stable-baseline/);
+    expect(result.stdout).toMatch(/Generating stable types for deployed\.mo/);
+    expect(result.stdout).toMatch(/Stable compatibility check passed/);
+  });
+
   test("old file in subdirectory (.old/src/ pattern)", async () => {
     const cwd = path.join(import.meta.dirname, "check-stable/subdirectory");
     const result = await cli(["check-stable", ".old/src/main.mo"], { cwd });

--- a/cli/tests/check-stable/mo-baseline-em/deployed.mo
+++ b/cli/tests/check-stable/mo-baseline-em/deployed.mo
@@ -1,0 +1,5 @@
+actor {
+  let a : Nat;
+  let b : Text;
+  let c : Bool;
+};

--- a/cli/tests/check-stable/mo-baseline-em/migrations/20250101_000000_Init.mo
+++ b/cli/tests/check-stable/mo-baseline-em/migrations/20250101_000000_Init.mo
@@ -1,0 +1,8 @@
+module {
+  public func migration(_ : {}) : { a : Nat; b : Text } {
+    {
+      a = 42;
+      b = "hello";
+    };
+  };
+};

--- a/cli/tests/check-stable/mo-baseline-em/migrations/20250201_000000_AddField.mo
+++ b/cli/tests/check-stable/mo-baseline-em/migrations/20250201_000000_AddField.mo
@@ -1,0 +1,9 @@
+module {
+  public func migration(old : { a : Nat; b : Text }) : {
+    a : Nat;
+    b : Text;
+    c : Bool;
+  } {
+    { old with c = true };
+  };
+};

--- a/cli/tests/check-stable/mo-baseline-em/mops.toml
+++ b/cli/tests/check-stable/mo-baseline-em/mops.toml
@@ -1,0 +1,14 @@
+[toolchain]
+moc = "1.12.0"
+
+[moc]
+args = ["--default-persistent-actors"]
+
+[canisters.backend]
+main = "src/main.mo"
+
+[canisters.backend.migrations]
+chain = "migrations"
+
+[canisters.backend.check-stable]
+path = "deployed.mo"

--- a/cli/tests/check-stable/mo-baseline-em/src/main.mo
+++ b/cli/tests/check-stable/mo-baseline-em/src/main.mo
@@ -1,0 +1,14 @@
+import Prim "mo:prim";
+
+// `d` is produced by no migration in the chain: M0254 on the 3-step path,
+// M0267 on the folded one. The fixture exists to keep it on the 3-step path.
+actor {
+  let a : Nat;
+  let b : Text;
+  let c : Bool;
+  let d : Int;
+
+  public func check() : async () {
+    Prim.debugPrint(debug_show { a; b; c; d });
+  };
+};


### PR DESCRIPTION
2.23.0 scoped the moc 1.12.0+ folded upgrade check to canisters with `[migrations]` and a **committed `.most`** baseline. The changelog, [`mops check-stable`'s docs](https://docs.mops.one/cli/dev/mops-check-stable) and [#624](https://github.com/caffeinelabs/mops/pull/624) all say `.mo` baselines are unaffected. They are not: `runStableCheck` compiles a `.mo` baseline to a scratch `.most`, then folds anyway.

The folded check is stricter — a field the initial actor requires that no migration produces fails as `M0267` instead of warning `M0254` — so anyone with `[migrations]`, a `.mo` baseline and moc 1.12.0+ can find a green `mops check` red after upgrading to 2.23.0, with nothing in the changelog to explain it.

## Before / After

An enhanced-migration canister whose chain never produces `d`, `[check-stable] path = "deployed.mo"`, moc 1.12.0:

```console
$ # before
src/main.mo:9.7-9.8: type error [M0267], initial actor requires field `d` of type
  Int; not found in the previous version — write a migration that produces it
✗ Stable compatibility check failed for canister 'backend'
$ echo $?
1
```

```console
$ # after
✓ Stable compatibility check passed for canister 'backend'
$ echo $?
0
```

## Why it evaded the tests

Every moc 1.12.0 fixture pairs the fold's two preconditions the way the feature intended. `check-stable/migrations-chain` has `[migrations]` and a `.most` baseline; `check/deployed-compatible` has a `.mo` baseline but no `[migrations]`, so `canUseStableBaselineCheck` is false and it never reaches the second fold. Nothing pinned the one corner where the two cross. `check-stable/mo-baseline-em` does now, and fails with `M0267` on `main` without this change.

Worth noting the second fold could not have been fixed with a guard: `if (isOldMostFile && canUseStableBaselineCheck(...))` is the exact condition the earlier fast path already returns on, so the block is unreachable once corrected. It is deleted rather than guarded, and `runFoldedStableCheck` loses its `baselineIsMostFile` parameter — "folded implies committed `.most`" now holds by construction instead of by argument.

## What is unchanged

- Committed `.most` baselines keep the fold, the source locations and the stricter `M0267`. That part of 2.23.0 was intended and stays.
- `mops check` already gated its own fold on `configuredMost.endsWith(".most")`, so only the `runStableCheck` path it delegates to was wrong.
- No docs change: the shipped prose describes this behavior correctly — it is the code that drifted.

Also going onto `v3` as part of [#756](https://github.com/caffeinelabs/mops/pull/756), which is where the bug was found, so the branches do not diverge.
