### PR TITLE
chore(perf): manual repro harness for PocketIC-under-gVisor memory blowup

### DIFF
--- a/.github/workflows/gvisor-repro.yml
+++ b/.github/workflows/gvisor-repro.yml
@@ -30,7 +30,8 @@ concurrency:
 jobs:
   repro:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # several runsc scenarios can each grind up to the harness timeout
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/gvisor-repro.yml
+++ b/.github/workflows/gvisor-repro.yml
@@ -1,0 +1,57 @@
+# Runs the perf/check-deploy-gvisor harness on an x86_64 runner — the
+# incident's architecture, which cannot be exercised from an arm64 machine
+# (gVisor has no binfmt support). Manual via workflow_dispatch, plus
+# automatically on PRs that touch the harness. Results land in the job log
+# as a markdown table to paste into perf/check-deploy-gvisor/RESULTS.md.
+name: gvisor-repro
+
+on:
+  workflow_dispatch:
+    inputs:
+      memory:
+        description: "container memory cap (memory-swap is set equal)"
+        required: false
+        default: "4g"
+      scenarios:
+        description: "comma-separated scenario filter (default: all)"
+        required: false
+        default: ""
+  pull_request:
+    paths:
+      - "perf/check-deploy-gvisor/**"
+      - "!perf/check-deploy-gvisor/RESULTS.md"
+      - ".github/workflows/gvisor-repro.yml"
+
+concurrency:
+  group: gvisor-repro-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repro:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gVisor and register runsc with docker
+        run: |
+          arch=$(uname -m)
+          url=https://storage.googleapis.com/gvisor/releases/release/latest/${arch}
+          sudo curl -fsSL -o /usr/local/bin/runsc ${url}/runsc
+          sudo curl -fsSL -o /usr/local/bin/containerd-shim-runsc-v1 ${url}/containerd-shim-runsc-v1
+          sudo chmod +x /usr/local/bin/runsc /usr/local/bin/containerd-shim-runsc-v1
+          echo '{"runtimes":{"runsc":{"path":"/usr/local/bin/runsc"}}}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          runsc --version
+          docker info --format '{{range $k, $v := .Runtimes}}{{$k}} {{end}}'
+
+      - name: Run repro harness
+        # PR runs use a 2g cap: an x86_64 runsc deploy climbs past 2.8 GiB but
+        # takes >15 min to get there, so 4g mostly measures the harness
+        # timeout — 2g (still 3× the runc peak) reaches a true cgroup OOM
+        # within the budget. Dispatch runs choose their own cap.
+        run: |
+          args=(--memory 2g --timeout 1500)
+          [ -n "${{ inputs.memory }}" ] && args=(--memory "${{ inputs.memory }}" --timeout 1500)
+          [ -n "${{ inputs.scenarios }}" ] && args+=(--scenarios "${{ inputs.scenarios }}")
+          sudo perf/check-deploy-gvisor/run.sh "${args[@]}"

--- a/.github/workflows/gvisor-repro.yml
+++ b/.github/workflows/gvisor-repro.yml
@@ -1,8 +1,9 @@
 # Runs the perf/check-deploy-gvisor harness on an x86_64 runner — the
-# incident's architecture, which cannot be exercised from an arm64 machine
-# (gVisor has no binfmt support). Manual via workflow_dispatch, plus
-# automatically on PRs that touch the harness. Results land in the job log
-# as a markdown table to paste into perf/check-deploy-gvisor/RESULTS.md.
+# architecture where the memory blowup manifests, which cannot be exercised
+# from an arm64 machine (gVisor has no binfmt support). Manual via
+# workflow_dispatch, plus automatically on PRs that touch the harness.
+# Results land in the job log as a markdown table to paste into
+# perf/check-deploy-gvisor/RESULTS.md.
 name: gvisor-repro
 
 on:

--- a/perf/check-deploy-gvisor/Dockerfile
+++ b/perf/check-deploy-gvisor/Dockerfile
@@ -27,6 +27,15 @@ RUN mkdir /opt/moc && arch="$(uname -m)" \
   | tar -xz -C /opt/moc \
   && /opt/moc/moc --version
 
+# moc for the EOP/wasm64 variant project (fixtures/eop): a 1.x compiler with
+# enhanced orthogonal persistence, fetched from the caffeinelabs fork, which
+# publishes Linux builds for both architectures.
+ARG MOC_EOP_VERSION=1.12.0
+RUN mkdir /opt/moc-eop && arch="$(uname -m)" \
+  && curl -fsSL "https://github.com/caffeinelabs/motoko/releases/download/${MOC_EOP_VERSION}/motoko-Linux-${arch}-${MOC_EOP_VERSION}.tar.gz" \
+  | tar -xz -C /opt/moc-eop \
+  && /opt/moc-eop/moc --version
+
 # pocket-ic: fetched directly for the same reason (mops 2.x hardcodes
 # x86_64-linux); the fixture pins it as a binary path, which check-deploy
 # supports. 15.0.0 is the current PocketIC release.
@@ -40,7 +49,8 @@ RUN arch="$(uname -m)" && case "$arch" in aarch64) picarch=arm64 ;; *) picarch="
 WORKDIR /project
 COPY perf/check-deploy-gvisor/fixtures/ fixtures/
 COPY backend/ backend/
-RUN cp fixtures/mops.toml mops.toml && mops install
+RUN cp fixtures/mops.toml mops.toml && mops install \
+  && (cd fixtures/eop && mops install)
 
 COPY perf/check-deploy-gvisor/container-run.sh /usr/local/bin/container-run.sh
 ENTRYPOINT ["/usr/local/bin/container-run.sh"]

--- a/perf/check-deploy-gvisor/Dockerfile
+++ b/perf/check-deploy-gvisor/Dockerfile
@@ -1,0 +1,46 @@
+# Repro image for the PocketIC-under-gVisor memory blowup.
+# Bakes everything at build time — mops, moc, the
+# pocket-ic server binary, and the installed dependency set — so the run
+# itself needs no network and measures only `mops build main --check-deploy`
+# on the production mops.one registry canister (backend/main).
+#
+# Build from the repo root:
+#   docker build -f perf/check-deploy-gvisor/Dockerfile -t mops-check-deploy-gvisor .
+# Run via perf/check-deploy-gvisor/run.sh (compares --runtime=runc vs runsc).
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl procps \
+  && rm -rf /var/lib/apt/lists/*
+
+# check-deploy landed in 2.21.0; its deployment path is unchanged through
+# 2.23.0, so any contemporary 2.x release measures the same behavior.
+ARG MOPS_VERSION=2.22.0
+RUN npm i -g ic-mops@${MOPS_VERSION} && mops --version
+
+# moc: fetched directly because mops 2.x only downloads x86_64 builds of
+# dfinity releases; dfinity ships Linux aarch64 tarballs since 0.14.x. The
+# fixture pins it as a [toolchain] binary path.
+ARG MOC_VERSION=0.14.14
+RUN mkdir /opt/moc && arch="$(uname -m)" \
+  && curl -fsSL "https://github.com/dfinity/motoko/releases/download/${MOC_VERSION}/motoko-Linux-${arch}-${MOC_VERSION}.tar.gz" \
+  | tar -xz -C /opt/moc \
+  && /opt/moc/moc --version
+
+# pocket-ic: fetched directly for the same reason (mops 2.x hardcodes
+# x86_64-linux); the fixture pins it as a binary path, which check-deploy
+# supports. 15.0.0 is the current PocketIC release.
+ARG POCKET_IC_VERSION=15.0.0
+RUN arch="$(uname -m)" && case "$arch" in aarch64) picarch=arm64 ;; *) picarch="$arch" ;; esac \
+  && curl -fsSL "https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_VERSION}/pocket-ic-${picarch}-linux.gz" \
+  | gunzip > /opt/pocket-ic \
+  && chmod +x /opt/pocket-ic \
+  && /opt/pocket-ic --version
+
+WORKDIR /project
+COPY perf/check-deploy-gvisor/fixtures/ fixtures/
+COPY backend/ backend/
+RUN cp fixtures/mops.toml mops.toml && mops install
+
+COPY perf/check-deploy-gvisor/container-run.sh /usr/local/bin/container-run.sh
+ENTRYPOINT ["/usr/local/bin/container-run.sh"]

--- a/perf/check-deploy-gvisor/Dockerfile.dockerignore
+++ b/perf/check-deploy-gvisor/Dockerfile.dockerignore
@@ -1,0 +1,4 @@
+*
+!backend
+!perf/check-deploy-gvisor/fixtures
+!perf/check-deploy-gvisor/container-run.sh

--- a/perf/check-deploy-gvisor/README.md
+++ b/perf/check-deploy-gvisor/README.md
@@ -44,6 +44,7 @@ self-contained.
 | probe-runc / probe-runsc | both | read 1 GiB untouched anonymous memory (culprit demonstration) |
 | deploy-runc / deploy-runsc | both | `mops build main --check-deploy` on the registry canister ([fixtures/mops.toml](fixtures/mops.toml)) |
 | deploy-runsc-limit | runsc | same, with `wasmMemoryLimit = 256 MiB` on the canister ([fixtures/mops-wasm-memory-limit.toml](fixtures/mops-wasm-memory-limit.toml)) |
+| deploy-eop-runc / deploy-eop-runsc | both | `mops build main --check-deploy` on an **EOP/wasm64** canister (moc 1.12, `persistent actor` + mo:core — [fixtures/eop](fixtures/eop)); the registry canister predates moc 1.x, so this variant uses a compact representative backend instead |
 | rounds-runc / rounds-runsc | both | replica-mode `mops test`: 4 canisters × 150 awaited self-calls on one PocketIC server |
 
 ## Requirements

--- a/perf/check-deploy-gvisor/README.md
+++ b/perf/check-deploy-gvisor/README.md
@@ -1,0 +1,132 @@
+# check-deploy under gVisor: memory repro
+
+Manual reproduction harness for a production failure mode: containers
+running PocketIC workloads under gVisor (`--runtime=runsc`) with a hard
+memory cap get OOM-killed (exit 137), while identical workloads under the
+default runtime (`runc`) fit comfortably. The deployment workload is a
+**real production canister** — `backend/main/main-canister.mo`, the mops.one
+registry canister, built with the repo's own dependency set — deployed to
+PocketIC exactly the way `mops build --check-deploy` does it (shipped in
+mops 2.21.0).
+
+The most recent run is committed in [RESULTS.md](RESULTS.md) — replace it
+wholesale when you re-run, like `perf/install-bench` does on the v3 branch.
+
+## Why this happens (mechanism)
+
+Linux satisfies the first **read** of a never-written anonymous page from a
+single shared zero page — committing no RAM. The IC's canister sandbox is
+designed around that guarantee: it reserves a multi-GiB Wasm heap per
+canister, and its SIGSEGV memory tracker, GC scans, and per-round dirty-page
+validation **read** across that space assuming reads are free.
+
+gVisor (`runsc`) reimplements the kernel's memory management **without a
+shared zero page**: the first read of an anonymous page commits a real,
+private, zeroed page, charged to the container's cgroup and not released
+while the process lives. Every page the replica machinery merely glances at
+becomes committed RAM. With `memory-swap == memory` (no swap, a common
+sandbox configuration) crossing the cap is an instant SIGKILL.
+
+The `probe` scenario demonstrates the mechanism in isolation: it reads 1 GiB
+of untouched anonymous memory without writing. Under runc that commits a few
+MiB of page tables; under runsc it commits the full 1 GiB.
+
+## Scenarios
+
+All scenarios run the same image with the same hard cap
+(`--memory 4g --memory-swap 4g` by default). Everything network-dependent
+(mops 2.22.0, moc, the pocket-ic binary, the installed dependency set) is
+baked into the image at build time, so the measured runs are offline and
+self-contained.
+
+| scenario | runtime | workload |
+|---|---|---|
+| probe-runc / probe-runsc | both | read 1 GiB untouched anonymous memory (culprit demonstration) |
+| deploy-runc / deploy-runsc | both | `mops build main --check-deploy` on the registry canister ([fixtures/mops.toml](fixtures/mops.toml)) |
+| deploy-runsc-limit | runsc | same, with `wasmMemoryLimit = 256 MiB` on the canister ([fixtures/mops-wasm-memory-limit.toml](fixtures/mops-wasm-memory-limit.toml)) |
+| rounds-runc / rounds-runsc | both | replica-mode `mops test`: 4 canisters × 150 awaited self-calls on one PocketIC server |
+
+## Requirements
+
+- A Linux host (x86_64 or arm64) with docker and [gVisor](https://gvisor.dev)
+  installed, with `runsc` registered as a docker runtime:
+
+  ```bash
+  arch=$(uname -m)
+  url=https://storage.googleapis.com/gvisor/releases/release/latest/${arch}
+  sudo curl -fsSL -o /usr/local/bin/runsc ${url}/runsc
+  sudo curl -fsSL -o /usr/local/bin/containerd-shim-runsc-v1 ${url}/containerd-shim-runsc-v1
+  sudo chmod +x /usr/local/bin/runsc /usr/local/bin/containerd-shim-runsc-v1
+  echo '{"runtimes":{"runsc":{"path":"/usr/local/bin/runsc"}}}' | sudo tee /etc/docker/daemon.json
+  sudo systemctl restart docker
+  ```
+
+- ≥ 6 GiB of memory available to docker.
+
+On a Mac, an [OrbStack](https://orbstack.dev) Linux machine works
+(`orb create ubuntu:noble <name>`, then the steps above inside it). OrbStack's
+own docker engine only ships runc. Note this gives you an **arm64** run —
+see the caveat below.
+
+## Run
+
+From the repo root (or anywhere — the script cd's itself):
+
+```bash
+perf/check-deploy-gvisor/run.sh
+```
+
+Options:
+
+```bash
+perf/check-deploy-gvisor/run.sh --memory 2g          # tighter cap
+perf/check-deploy-gvisor/run.sh --scenarios probe-runc,probe-runsc --no-build
+perf/check-deploy-gvisor/run.sh --timeout 1200
+```
+
+The script builds the image (BuildKit required — it uses a per-Dockerfile
+dockerignore), runs each scenario, samples the container's **host-side
+cgroup accounting** (`memory.peak` / `memory.current` — the numbers the OOM
+killer acts on) once a second, and prints a markdown table to paste into
+RESULTS.md. For the probe scenarios it additionally reports the **read
+cost**: committed memory after the read pass minus committed memory before
+it. The container also logs its own top-RSS processes every 2 s for
+attribution; under runsc that in-container view is the sentry's virtualized
+accounting and understates the host commit — trust the host-side column.
+
+## Interpreting results, and the x86_64 caveat
+
+- The **probe pair is the culprit demonstration**: identical binary,
+  identical read-only workload — a few MiB committed under runc, ~1 GiB
+  under runsc. That is the docker `--runtime` setting turning free reads
+  into committed RAM.
+- **Architecture matters for the workload scenarios — the blowup is
+  x86_64-specific.** On x86_64 (see RESULTS.md) the runsc deploy scenario
+  reproduces it: the check that runc finishes in ~17 s at 0.64 GiB grinds
+  for 15+ minutes committing multiple GiB. On arm64 the same workloads stay
+  under 1 GiB with runsc ≈ runc: the aarch64 canister sandbox evidently
+  reads far less untouched memory than the x86_64 one (SIGSEGV-driven
+  PROT_READ window prefetch over the Wasm heap). An x86_64 image cannot be
+  emulated on an arm64 host for this purpose — gVisor has no binfmt/Rosetta
+  support (`exec format error`) — use the **`gvisor-repro` GitHub
+  workflow**, which runs this harness on an x86_64 runner (auto on PRs
+  touching the harness, manual via workflow_dispatch).
+- **deploy-runsc-limit** answers whether `[canisters.<name>].wasmMemoryLimit`
+  bounds the commit: it does not (x86_64: 2.73 vs 2.80 GiB — noise). As the
+  probe implies, the commit is driven by replica-machinery reads, not by
+  what the canister allocates, so no canister-level setting can bound it.
+
+## Portability notes
+
+- The image fetches moc and pocket-ic directly instead of via
+  `mops toolchain`, because mops 2.x only downloads x86_64 Linux builds of
+  both; the fixtures pin each as a `[toolchain]` **binary path**, a supported
+  mops 2.x mechanism (`mops build` ignores `DFX_MOC_PATH` — its moc
+  resolution is pin-or-`dfx cache show`).
+- mops is pinned to **2.22.0**; `--check-deploy` landed in 2.21.0 and its
+  deployment path is unchanged through 2.23.0, so any contemporary 2.x
+  release measures the same behavior.
+- moc is **0.14.14** (the repo's pin) building a **wasm32** canister.
+  Projects on moc 1.x build under enhanced orthogonal persistence (wasm64);
+  a one-off EOP variant measured on arm64 showed the same order of
+  magnitude (see RESULTS.md).

--- a/perf/check-deploy-gvisor/RESULTS.md
+++ b/perf/check-deploy-gvisor/RESULTS.md
@@ -1,0 +1,88 @@
+# Last runs
+
+Committed manually after each meaningful run — replace this file wholesale.
+See README.md for the scenario definitions and how to reproduce.
+
+## x86_64 — REPRODUCED
+
+- **date**: 2026-08-14, [gvisor-repro workflow run 31784043015](https://github.com/caffeinelabs/mops/actions/runs/31784043015)
+- **host**: GitHub `ubuntu-latest` (x86_64, 4 vCPU, 16 GiB), gVisor
+  `release-latest` (systrap platform)
+- **image**: ic-mops 2.22.0 · moc 0.14.14 (Linux-x86_64) · pocket-ic 15.0.0
+- **caps**: `--memory 4g --memory-swap 4g`, 900s per-scenario harness timeout
+
+| scenario | runtime | variant | mem cap | outcome | peak cgroup mem | wall time |
+|---|---|---|---|---|---|---|
+| probe-runc | `--runtime=runc` | probe | 4g | passed | 0.01 GiB (read cost **0.00 GiB**) | 28s |
+| probe-runsc | `--runtime=runsc` | probe | 4g | passed | 1.04 GiB (read cost **1.00 GiB**) | 29s |
+| deploy-runc | `--runtime=runc` | plain | 4g | passed | **0.64 GiB** | **17s** |
+| deploy-runsc | `--runtime=runsc` | plain | 4g | killed by harness timeout, still running | **2.80 GiB and climbing** | 901s |
+| deploy-runsc-limit | `--runtime=runsc` | wasm-memory-limit | 4g | killed by harness timeout, still running | **2.73 GiB and climbing** | 902s |
+| rounds-runc | `--runtime=runc` | rounds | 4g | passed | 0.62 GiB | 8s |
+| rounds-runsc | `--runtime=runsc` | rounds | 4g | failed (PocketIC client timeout) | 0.55 GiB | 43s |
+
+(The run predates the harness's explicit timeout labeling — the two runsc
+deploy rows were reported as `OOM-killed (exit 137)` because the harness's
+own `docker kill` at 900s also exits 137. The log's "timeout after 900s —
+killing container" lines are unambiguous. PR-triggered runs now use a 2 GiB
+cap and a 1500s timeout so the kill is a true cgroup OOM.)
+
+### Reading
+
+- **This is the production failure mode.** The identical
+  `mops build main --check-deploy` of the registry canister completes under
+  runc in **17 seconds at 0.64 GiB** — and under runsc was **still executing
+  after 15 minutes with 2.8 GiB committed and rising** when the harness
+  killed it. The `--runtime` flag is the only difference. A container
+  sharing its cap with other processes crosses the cgroup limit on that
+  curve and is SIGKILLed — exit 137. The grind is a failure mode of its own:
+  checks that do not OOM stall for tens of minutes.
+- **`wasmMemoryLimit` does NOT prevent it**: 2.73 vs 2.80 GiB is noise. As
+  the probe predicts, the memory is committed by replica-machinery *reads*
+  (the canister sandbox's page tracking over the Wasm heap), not by what the
+  canister allocates — no canister-level setting can bound it.
+- **The probe pins the mechanism**: reading 1 GiB of untouched anonymous
+  memory commits 0.00 GiB under runc and 1.00 GiB under runsc.
+- rounds-runsc failing on a PocketIC client timeout is itself part of the
+  finding: x86_64 runsc slows the replica by well over an order of
+  magnitude, so client-side timeouts fire long before memory does.
+
+## arm64 (Apple Silicon, local) — mechanism only
+
+- **date**: 2026-08-14
+- **host**: OrbStack Ubuntu noble machine on darwin arm64 (aarch64),
+  kernel 7.0.11-orbstack, docker 29.1.3, gVisor `release-20260810.0`
+  (systrap), 15 GiB VM memory
+- **image**: ic-mops 2.22.0 · moc 0.14.14 (Linux-aarch64) · pocket-ic 15.0.0
+  (arm64-linux)
+- **caps**: `--memory 4g --memory-swap 4g`
+
+| scenario | runtime | variant | mem cap | outcome | peak cgroup mem | wall time |
+|---|---|---|---|---|---|---|
+| probe-runc | `--runtime=runc` | probe | 4g | passed | 0.08 GiB (read cost **0.00 GiB**) | 28s |
+| probe-runsc | `--runtime=runsc` | probe | 4g | passed | 1.03 GiB (read cost **1.00 GiB**) | 28s |
+| deploy-runc | `--runtime=runc` | plain | 4g | passed | 0.71 GiB | 11s |
+| deploy-runsc | `--runtime=runsc` | plain | 4g | passed | 0.71 GiB | 11s |
+| deploy-runsc-limit | `--runtime=runsc` | wasm-memory-limit | 4g | passed | 0.85 GiB | 12s |
+| rounds-runc | `--runtime=runc` | rounds | 4g | passed | 0.57 GiB | 4s |
+| rounds-runsc | `--runtime=runsc` | rounds | 4g | passed | 0.62 GiB | 8s |
+
+One-off side experiments on the same arm64 host:
+
+| experiment | runc | runsc |
+|---|---|---|
+| check-deploy of **8** registry canisters in one run (one PocketIC server) | 0.86 GiB, passed | 0.90 GiB, passed |
+| check-deploy of a minimal **moc 1.12 EOP/wasm64** canister | 0.55 GiB, passed | 0.68 GiB, passed |
+| amd64 image under runsc on arm64 | — | `exec format error` (gVisor has no binfmt/Rosetta) |
+
+### Reading
+
+- The zero-page mechanism reproduces identically on arm64 (probe), but the
+  workload blowup does not: runsc ≈ runc on every mops workload, everything
+  passes in seconds. The x86_64 canister sandbox's memory tracking
+  (SIGSEGV-driven PROT_READ window prefetch over the Wasm heap) evidently
+  reads — and under gVisor commits — orders of magnitude more untouched
+  memory than the aarch64 implementation, and is dramatically slower under
+  runsc's syscall interception.
+- Deploy/rounds peaks vary ±0.1 GiB between runs; treat sub-0.1 GiB deltas
+  as noise.

--- a/perf/check-deploy-gvisor/container-run.sh
+++ b/perf/check-deploy-gvisor/container-run.sh
@@ -12,6 +12,9 @@ case "${VARIANT:-plain}" in
   wasm-memory-limit)
     cp fixtures/mops-wasm-memory-limit.toml mops.toml
     ;;
+  eop)
+    cd fixtures/eop
+    ;;
   rounds)
     # Four replica test files, each deploying a fresh canister to the shared
     # PocketIC server and awaiting an empty self-call 150 times. Kept small

--- a/perf/check-deploy-gvisor/container-run.sh
+++ b/perf/check-deploy-gvisor/container-run.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Container entrypoint for the check-deploy gVisor repro. VARIANT selects the
+# workload (see README.md):
+#   plain             mops build main --check-deploy on the registry canister
+#   wasm-memory-limit same, with a 256 MiB wasmMemoryLimit on the canister
+#   rounds            replica-mode mops test driving ~4800 execution rounds
+#   probe             read 1 GiB of untouched anonymous memory, no writes
+set -eu
+
+case "${VARIANT:-plain}" in
+  plain) ;;
+  wasm-memory-limit)
+    cp fixtures/mops-wasm-memory-limit.toml mops.toml
+    ;;
+  rounds)
+    # Four replica test files, each deploying a fresh canister to the shared
+    # PocketIC server and awaiting an empty self-call 150 times. Kept small
+    # per ingress message because x86_64 runsc slows execution by an order of
+    # magnitude and the PocketIC client times out on long-running ingress
+    # calls; the point is round count, not per-round work.
+    mkdir -p test
+    for n in 1 2 3 4; do
+      cat > "test/load$n.test.mo" <<'M'
+// @testmode replica
+persistent actor {
+  public func tick() : async () {};
+  public func runTests() : async () {
+    var r = 0;
+    while (r < 150) {
+      await tick();
+      r += 1;
+    };
+  };
+};
+M
+    done
+    ;;
+  probe)
+    # Zero-page probe: under runc the reads hit the shared zero page
+    # and commit ~nothing; under gVisor every read commits a real page. The
+    # runner samples the cgroup around the sleeps to isolate the read cost.
+    exec node -e '
+      const SZ = 1 << 30;
+      const buf = Buffer.allocUnsafeSlow(SZ);
+      setTimeout(() => {
+        let s = 0;
+        for (let i = 0; i < SZ; i += 4096) s += buf[i];
+        setTimeout(() => { console.log("probe done, sum", s); }, 20000);
+      }, 8000);
+    '
+    ;;
+  *)
+    echo "unknown VARIANT: ${VARIANT}" >&2
+    exit 2
+    ;;
+esac
+
+# In-container view: top RSS consumers every 2s. Under runc this is host
+# truth; under gVisor it is the sentry's virtualized accounting, so treat it
+# as attribution only — the host-side cgroup numbers in run.sh are the ground
+# truth for the memory cap.
+(
+  while sleep 2; do
+    echo "--- mem sample $(date -u +%H:%M:%S) ---"
+    ps -eo rss=,comm= | sort -rn | head -4 | awk '{printf "%7.1f MiB  %s\n", $1/1024, $2}'
+  done
+) &
+
+if [ "${VARIANT:-plain}" = rounds ]; then
+  exec mops test
+fi
+exec mops build main --check-deploy

--- a/perf/check-deploy-gvisor/fixtures/eop/main.mo
+++ b/perf/check-deploy-gvisor/fixtures/eop/main.mo
@@ -1,0 +1,33 @@
+// Representative current-generation Motoko backend: persistent actor,
+// mo:core collections, some real init work so the deployment check
+// executes actual rounds — the structure of a typical wasm64/EOP app.
+import Map "mo:core/Map";
+import Nat "mo:core/Nat";
+import Text "mo:core/Text";
+
+persistent actor {
+  let users = Map.empty<Nat, Text>();
+  let index = Map.empty<Text, Nat>();
+  var revision = 0;
+
+  // init: populate some state so installation is not a no-op
+  var i = 0;
+  while (i < 1000) {
+    let name = "user-" # Nat.toText(i);
+    Map.add(users, Nat.compare, i, name);
+    Map.add(index, Text.compare, name, i);
+    i += 1;
+  };
+
+  public func register(name : Text) : async Nat {
+    let id = Map.size(users);
+    Map.add(users, Nat.compare, id, name);
+    Map.add(index, Text.compare, name, id);
+    revision += 1;
+    id;
+  };
+
+  public query func lookup(name : Text) : async ?Nat {
+    Map.get(index, Text.compare, name);
+  };
+};

--- a/perf/check-deploy-gvisor/fixtures/eop/mops.toml
+++ b/perf/check-deploy-gvisor/fixtures/eop/mops.toml
@@ -1,0 +1,16 @@
+# EOP/wasm64 variant project: a persistent actor on mo:core compiled with
+# moc 1.x (enhanced orthogonal persistence, 64-bit main memory) — the shape
+# of a current-generation Motoko backend. The repo's registry canister
+# cannot be used here without a full EOP migration (its dependencies and
+# actor declarations predate moc 1.x), so this is a compact representative
+# canister instead.
+
+[dependencies]
+core = "2.6.1"
+
+[canisters]
+main = "main.mo"
+
+[toolchain]
+moc = "/opt/moc-eop/moc"
+pocket-ic = "/opt/pocket-ic"

--- a/perf/check-deploy-gvisor/fixtures/mops-wasm-memory-limit.toml
+++ b/perf/check-deploy-gvisor/fixtures/mops-wasm-memory-limit.toml
@@ -1,0 +1,25 @@
+# Same manifest as mops.toml, with a per-canister wasmMemoryLimit (256 MiB)
+# applied by `mops build --check-deploy` at canister creation. Used to answer
+# whether limiting the canister's Wasm heap bounds the memory the check
+# commits under gVisor.
+
+[dependencies]
+base = "0.14.14"
+time-consts = "1.0.1"
+map = "9.0.1"
+ic = "3.2.0"
+backup = "3.0.0"
+sha2 = "0.1.0"
+vector = "0.4.0"
+http-types = "1.0.1"
+datetime = "1.0.0"
+principal-ext = "0.1.0"
+telegram-bot = "0.1.1"
+
+[canisters.main]
+main = "backend/main/main-canister.mo"
+wasmMemoryLimit = 268435456
+
+[toolchain]
+moc = "/opt/moc/moc"
+pocket-ic = "/opt/pocket-ic"

--- a/perf/check-deploy-gvisor/fixtures/mops.toml
+++ b/perf/check-deploy-gvisor/fixtures/mops.toml
@@ -1,0 +1,27 @@
+# Manifest for the check-deploy gVisor repro (perf/check-deploy-gvisor).
+#
+# Dependencies mirror the repo root mops.toml so backend/main (the production
+# mops.one registry canister) builds unchanged. moc and pocket-ic are
+# binary-path pins (a supported [toolchain] form): mops 2.x downloads
+# dfinity-release builds of both tools for x86_64 only, and this repro also
+# runs on arm64 hosts — the Dockerfile fetches the right binaries instead.
+
+[dependencies]
+base = "0.14.14"
+time-consts = "1.0.1"
+map = "9.0.1"
+ic = "3.2.0"
+backup = "3.0.0"
+sha2 = "0.1.0"
+vector = "0.4.0"
+http-types = "1.0.1"
+datetime = "1.0.0"
+principal-ext = "0.1.0"
+telegram-bot = "0.1.1"
+
+[canisters]
+main = "backend/main/main-canister.mo"
+
+[toolchain]
+moc = "/opt/moc/moc"
+pocket-ic = "/opt/pocket-ic"

--- a/perf/check-deploy-gvisor/run.sh
+++ b/perf/check-deploy-gvisor/run.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Host-side runner for the check-deploy gVisor OOM repro (see README.md).
+# Runs identical containerized workloads under runc and under gVisor (runsc)
+# with identical hard memory caps, tracks the container's cgroup memory from
+# the host, and prints a markdown results table.
+#
+# Requires a Linux host with docker and the runsc runtime configured (see
+# README.md). Run from anywhere:
+#   perf/check-deploy-gvisor/run.sh [--memory 4g] [--timeout 900]
+#     [--scenarios probe-runc,probe-runsc,...] [--no-build]
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+IMAGE=mops-check-deploy-gvisor
+MEMORY=4g
+TIMEOUT=900
+SCENARIOS=probe-runc,probe-runsc,deploy-runc,deploy-runsc,deploy-runsc-limit,rounds-runc,rounds-runsc
+BUILD=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --memory) MEMORY=$2; shift 2 ;;
+    --timeout) TIMEOUT=$2; shift 2 ;;
+    --scenarios) SCENARIOS=$2; shift 2 ;;
+    --image) IMAGE=$2; shift 2 ;;
+    --no-build) BUILD=0; shift ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ $BUILD -eq 1 ]]; then
+  # BuildKit is required for the per-Dockerfile dockerignore, which keeps the
+  # build context to backend/ + fixtures instead of the whole repo.
+  DOCKER_BUILDKIT=1 docker build -f perf/check-deploy-gvisor/Dockerfile -t "$IMAGE" .
+fi
+
+# The container's cgroup file, read from the host — the accounting the OOM
+# killer acts on. Handles both the systemd and cgroupfs driver layouts.
+cgroup_file() {
+  local cid=$1 name=$2 f
+  for f in \
+    "/sys/fs/cgroup/system.slice/docker-${cid}.scope/$name" \
+    "/sys/fs/cgroup/docker/${cid}/$name"; do
+    [[ -r $f ]] && { echo "$f"; return; }
+  done
+  echo ""
+}
+
+gib() { awk -v b="${1:-0}" 'BEGIN{printf "%.2f GiB", b/1073741824}'; }
+
+declare -a ROWS
+
+run_scenario() {
+  local name=$1 runtime=$2 variant=$3
+  local cname="check-deploy-gvisor-$name"
+  echo
+  echo "=== scenario $name: --runtime=$runtime, VARIANT=$variant, --memory=$MEMORY (swap=mem) ==="
+  docker rm -f "$cname" >/dev/null 2>&1 || true
+  local cid
+  cid=$(docker run -d --name "$cname" \
+    --runtime "$runtime" \
+    --memory "$MEMORY" --memory-swap "$MEMORY" \
+    -e "VARIANT=$variant" \
+    "$IMAGE")
+
+  local peakf currentf start now peak="" pre_read="" timed_out=0
+  peakf=$(cgroup_file "$cid" memory.peak)
+  currentf=$(cgroup_file "$cid" memory.current)
+  start=$(date +%s)
+  while :; do
+    [[ -n $peakf ]] && peak=$(cat "$peakf" 2>/dev/null || echo "$peak")
+    now=$(date +%s)
+    # probe: memory committed after alloc but before the reads begin at t=8s
+    if [[ $variant == probe && -z $pre_read && $((now - start)) -ge 6 ]]; then
+      pre_read=$(cat "$currentf" 2>/dev/null || echo "")
+    fi
+    # growth curve for the log, one point a minute
+    if (( (now - start) % 60 == 0 && now - start > 0 )); then
+      echo "  [$((now - start))s] committed $(gib "$(cat "$currentf" 2>/dev/null || echo 0)")"
+    fi
+    if [[ $(docker inspect -f '{{.State.Running}}' "$cid") != true ]]; then
+      break
+    fi
+    if (( now - start > TIMEOUT )); then
+      echo "timeout after ${TIMEOUT}s — killing container" >&2
+      timed_out=1
+      docker kill "$cid" >/dev/null || true
+      break
+    fi
+    sleep 1
+  done
+  local elapsed=$(( $(date +%s) - start ))
+
+  local exit_code oom outcome
+  exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$cid")
+  oom=$(docker inspect -f '{{.State.OOMKilled}}' "$cid")
+  # gVisor kills the whole sandbox on a cgroup OOM and docker sometimes
+  # reports that as exit 137 without setting OOMKilled, so 137 counts as OOM
+  # — unless the kill was ours (harness timeout with the workload still
+  # running and committing).
+  if [[ $exit_code == 0 ]]; then outcome="passed"
+  elif [[ $timed_out == 1 ]]; then outcome="harness timeout at ${TIMEOUT}s, still running"
+  elif [[ $oom == true || $exit_code == 137 ]]; then outcome="OOM-killed (exit $exit_code)"
+  else outcome="failed (exit $exit_code)"
+  fi
+
+  local peak_h="n/a"
+  [[ -n $peak ]] && peak_h=$(gib "$peak")
+  if [[ $variant == probe && -n $pre_read && -n $peak ]]; then
+    peak_h="$peak_h (read cost $(gib $((peak - pre_read))))"
+  fi
+
+  echo "--- last container output ---"
+  docker logs --tail 15 "$cname" 2>&1 | sed 's/^/    /'
+  echo "outcome=$outcome peak=$peak_h elapsed=${elapsed}s"
+  ROWS+=("| $name | \`--runtime=$runtime\` | $variant | $MEMORY | $outcome | $peak_h | ${elapsed}s |")
+  docker rm -f "$cname" >/dev/null 2>&1 || true
+}
+
+[[ ",$SCENARIOS," == *,probe-runc,* ]] && run_scenario probe-runc runc probe
+[[ ",$SCENARIOS," == *,probe-runsc,* ]] && run_scenario probe-runsc runsc probe
+[[ ",$SCENARIOS," == *,deploy-runc,* ]] && run_scenario deploy-runc runc plain
+[[ ",$SCENARIOS," == *,deploy-runsc,* ]] && run_scenario deploy-runsc runsc plain
+[[ ",$SCENARIOS," == *,deploy-runsc-limit,* ]] && run_scenario deploy-runsc-limit runsc wasm-memory-limit
+[[ ",$SCENARIOS," == *,rounds-runc,* ]] && run_scenario rounds-runc runc rounds
+[[ ",$SCENARIOS," == *,rounds-runsc,* ]] && run_scenario rounds-runsc runsc rounds
+
+echo
+echo "| scenario | runtime | variant | mem cap | outcome | peak cgroup mem | wall time |"
+echo "|---|---|---|---|---|---|---|"
+printf '%s\n' "${ROWS[@]}"

--- a/perf/check-deploy-gvisor/run.sh
+++ b/perf/check-deploy-gvisor/run.sh
@@ -15,7 +15,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 IMAGE=mops-check-deploy-gvisor
 MEMORY=4g
 TIMEOUT=900
-SCENARIOS=probe-runc,probe-runsc,deploy-runc,deploy-runsc,deploy-runsc-limit,rounds-runc,rounds-runsc
+SCENARIOS=probe-runc,probe-runsc,deploy-runc,deploy-runsc,deploy-runsc-limit,deploy-eop-runc,deploy-eop-runsc,rounds-runc,rounds-runsc
 BUILD=1
 
 while [[ $# -gt 0 ]]; do
@@ -123,6 +123,8 @@ run_scenario() {
 [[ ",$SCENARIOS," == *,deploy-runc,* ]] && run_scenario deploy-runc runc plain
 [[ ",$SCENARIOS," == *,deploy-runsc,* ]] && run_scenario deploy-runsc runsc plain
 [[ ",$SCENARIOS," == *,deploy-runsc-limit,* ]] && run_scenario deploy-runsc-limit runsc wasm-memory-limit
+[[ ",$SCENARIOS," == *,deploy-eop-runc,* ]] && run_scenario deploy-eop-runc runc eop
+[[ ",$SCENARIOS," == *,deploy-eop-runsc,* ]] && run_scenario deploy-eop-runsc runsc eop
 [[ ",$SCENARIOS," == *,rounds-runc,* ]] && run_scenario rounds-runc runc rounds
 [[ ",$SCENARIOS," == *,rounds-runsc,* ]] && run_scenario rounds-runsc runsc rounds
 


### PR DESCRIPTION
Containers running PocketIC workloads under gVisor (`--runtime=runsc`) with a hard memory cap can be OOM-killed (exit 137), while the identical workloads under runc fit in well under 1 GiB. `perf/check-deploy-gvisor/` makes that comparison reproducible: one image (mops 2.22.0, moc 0.14.14, pocket-ic 15.0.0, the production mops.one registry canister with the repo's real dependency set, all baked at build time), run under both runtimes with identical caps while the host samples the cgroup accounting the OOM killer acts on. Structure mirrors `perf/install-bench` on the v3 branch: manual run, committed `RESULTS.md`, replaced wholesale on re-runs. The `gvisor-repro` workflow runs the harness on an x86_64 runner — the architecture where the blowup manifests, unreachable from arm64 machines (gVisor has no binfmt support) — automatically on PRs touching the harness and manually via workflow_dispatch.

Scenarios: a **zero-page probe** (read 1 GiB of untouched anonymous memory, no writes), **`mops build main --check-deploy`** plain and with a 256 MiB `wasmMemoryLimit`, and a rounds-heavy replica `mops test`.

## What the committed runs show

**x86_64 (CI): the blowup reproduces.** `mops build main --check-deploy` of the registry canister completes under runc in **17 s at 0.64 GiB peak**; under runsc the same command was **still executing after 15 minutes with 2.80 GiB committed and climbing** when the harness killed it. A container sharing its cap with other processes crosses the cgroup limit on that curve — exit 137. The grind is a failure mode of its own: checks that don't OOM stall for tens of minutes.

**`wasmMemoryLimit` does not help**: 2.73 vs 2.80 GiB is noise. The probe explains why — the commit is driven by replica-machinery *reads* (the canister sandbox's page tracking over the Wasm heap), which gVisor charges as real memory because it has no shared zero page (probe: 0.00 GiB committed under runc vs 1.00 GiB under runsc for the same 1 GiB read). No canister-level setting can bound reads the replica performs.

**arm64 (local): mechanism only.** The probe reproduces identically, but every mops workload (single install, ×8 canisters, moc 1.12 EOP variant, thousands of rounds) stays under 1 GiB with runsc ≈ runc — the aarch64 canister sandbox reads far less untouched memory than the x86_64 one. Details and side experiments in RESULTS.md.

## Follow-up worth flagging

PR-triggered CI runs use a 2 GiB cap (still 3× the runc peak) so the runsc deploy reaches a true cgroup OOM within the time budget; dispatch runs choose their own cap. The rounds scenario under x86_64 runsc currently fails on a PocketIC client timeout before memory becomes interesting — itself evidence of the >10× execution slowdown — and is kept as a secondary scenario.

No CLI changes and no changelog entry — this is repo-local tooling, like `perf/install-bench`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)