### PR TITLE
docs: port the v3 docs audit to the 2.x doc trees

### DIFF
--- a/docs/docs/cli/2-publish/05-mops-owner.md
+++ b/docs/docs/cli/2-publish/05-mops-owner.md
@@ -32,6 +32,13 @@ Remove package owner.
 mops owner remove <principal>
 ```
 
+### `--yes`
+
+`mops owner add` and `mops owner remove` ask for confirmation. Pass `--yes` to skip the prompt (required in non-interactive environments like CI):
+```
+mops owner add <principal> --yes
+```
+
 ## Example
 
 Imagine you have a package named `hello` and you want to add the principal `2d2zu-vaaaa-aaaak-qb6pq-cai` as an owner.

--- a/docs/docs/cli/2-publish/06-mops-maintainer.md
+++ b/docs/docs/cli/2-publish/06-mops-maintainer.md
@@ -32,6 +32,13 @@ Remove package maintainer.
 mops maintainer remove <principal>
 ```
 
+### `--yes`
+
+`mops maintainer add` and `mops maintainer remove` ask for confirmation. Pass `--yes` to skip the prompt (required in non-interactive environments like CI):
+```
+mops maintainer add <principal> --yes
+```
+
 ## Example
 
 Imagine you have a package named `hello` and you want to add the principal `2d2zu-vaaaa-aaaak-qb6pq-cai` as a maintainer.

--- a/docs/docs/cli/3-user/01-mops-user-import.md
+++ b/docs/docs/cli/3-user/01-mops-user-import.md
@@ -19,6 +19,14 @@ This command accepts PEM file contents, not a path to a file.
 
 Supported keys are secp256k1 and Ed25519, in SEC1 (`-----BEGIN EC PRIVATE KEY-----`) or PKCS#8 (`-----BEGIN PRIVATE KEY-----`) format. This covers identities exported by `dfx` and `icp-cli`.
 
+### `--no-encrypt`
+
+Do not ask for a password to encrypt the identity. The identity is stored unencrypted, so commands that use it never prompt for a password — useful in CI and scripts.
+
+```
+mops user import --no-encrypt -- <pem_data>
+```
+
 ### Import identity from DFX
 
 ```

--- a/docs/docs/cli/4-dev/01-mops-test.md
+++ b/docs/docs/cli/4-dev/01-mops-test.md
@@ -10,7 +10,14 @@ Mops can run Motoko unit tests
 mops test
 ```
 
-Put your tests in `test/*.test.mo` files.
+Put your tests in `*.test.mo` files inside a `test/` or `tests/` directory (nested subdirectories work too).
+
+If a `test/lib.mo` (or `tests/lib.mo`) file exists, it is the **only** file run — use it as an entry point that imports your other tests.
+
+Pass a filter to run a subset of files — `mops test nat` runs every `*nat*.mo` file under the test directory (the `.test.mo` suffix is not required for filtered files):
+```
+mops test nat
+```
 
 All tests run as quickly as possible thanks to parallel execution.
 
@@ -60,12 +67,16 @@ Available modes:
 
 - `interpreter` - run tests via `moc -r` (default)
 - `wasi` - compile test file to wasm and execute it with `wasmtime`. Useful, when you use `to_candid`/`from_candid`, or if you get stackoverflow errors.
+- `replica` - deploy test files as canisters to a local replica ([`--replica`](#--replica) selects which one). See [Replica tests](#replica-tests).
 
 
-You can also specify `wasi` mode for a specific test file by adding the line below as the first line in the test file
+You can also specify `wasi` or `replica` mode for a specific test file by adding one of these markers to the file (on a line of its own, with nothing else on the line):
 ```
 // @testmode wasi
+// @testmode replica
 ```
+
+Test files that define an actor run in `replica` mode automatically.
 
 ### `--replica`
 
@@ -128,8 +139,6 @@ actor {
   };
 };
 ```
-
-Make sure your actor doesn't have a name `actor {`.
 
 Make sure your actor has `runTests` method.
 

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -11,7 +11,7 @@ Run Motoko benchmarks.
 mops bench [filter]
 ```
 
-Put your benchmark code in `bench/*.bench.mo` files.
+Put your benchmark code in `*.bench.mo` files inside a `bench/` or `benchmark/` directory (nested subdirectories work too). With a `[filter]` argument, every `*<filter>*.mo` file under those directories runs — the `.bench.mo` suffix is not required for filtered files.
 
 It is necessary to use [bench package](https://mops.one/bench) to write benchmarks.
 

--- a/docs/docs/cli/4-dev/03-mops-build.md
+++ b/docs/docs/cli/4-dev/03-mops-build.md
@@ -175,6 +175,8 @@ Each canister configuration supports:
 - `args` - Additional compiler arguments for this specific canister (optional)
 - `initArg` - Candid-encoded initialization arguments (optional)
 - `candid` - Path to the Candid interface file (optional, for compatibility checking)
+- `wasmMemoryLimit` - Wasm memory limit in bytes applied by [`--check-deploy`](#--check-deploy) (optional)
+- `[canisters.<name>.migrations]` and `[canisters.<name>.check-stable]` subtables — see the [`mops.toml` reference](../../09-mops.toml.md#canisters)
 
 You can also set global build settings:
 ```toml

--- a/docs/docs/cli/4-dev/mops-docs/41-mops-docs-generate.md
+++ b/docs/docs/cli/4-dev/mops-docs/41-mops-docs-generate.md
@@ -15,7 +15,7 @@ mops docs generate [options]
 ## Options
 
 - `--source <source>` - Source directory containing .mo files (default: `src`)
-- `--output <output>` - Output directory for generated documentation (default: `docs`)
+- `--output <output>`, `-o` - Output directory for generated documentation (default: `docs`)
 - `--format <format>` - Output format: `md`, `adoc`, or `html` (default: `md`)
 
 ## Description

--- a/docs/docs/cli/5-toolchain/01-toolchain-overview.md
+++ b/docs/docs/cli/5-toolchain/01-toolchain-overview.md
@@ -22,8 +22,8 @@ When you run `mops install` command, Mops will install the specified version of 
 
 You can use [`mops toolchain use`](./03-mops-toolchain-use.md) command to install specific tool version and update `mops.toml` file.
 ```
-mops toolchain use moc 0.10.3
-mops toolchain use wasmtime 16.0.0
+mops toolchain use moc 1.0.0
+mops toolchain use wasmtime 41.0.0
 mops toolchain use pocket-ic 15.0.0
 mops toolchain use lintoko 0.7.0
 mops toolchain use wasm-opt 131
@@ -37,8 +37,8 @@ You can manually edit `mops.toml` file to specify exact versions of each tool.
 
 ```toml
 [toolchain]
-moc = "0.10.3"
-wasmtime = "16.0.0"
+moc = "1.0.0"
+wasmtime = "41.0.0"
 lintoko = "0.7.0"
 pocket-ic = "15.0.0"
 wasm-opt = "131"

--- a/docs/docs/cli/5-toolchain/03-mops-toolchain-use.md
+++ b/docs/docs/cli/5-toolchain/03-mops-toolchain-use.md
@@ -15,9 +15,9 @@ mops toolchain use <tool> [version]
 
 Install specific tool version
 ```
-mops toolchain use moc 0.10.3
-mops toolchain use wasmtime 16.0.0
-mops toolchain use pocket-ic 1.0.0
+mops toolchain use moc 1.0.0
+mops toolchain use wasmtime 41.0.0
+mops toolchain use pocket-ic 15.0.0
 mops toolchain use lintoko 0.7.0
 ```
 

--- a/docs/docs/cli/5-toolchain/04-mops-toolchain-update.md
+++ b/docs/docs/cli/5-toolchain/04-mops-toolchain-update.md
@@ -5,15 +5,17 @@ sidebar_label: mops toolchain update
 
 # `mops toolchain update`
 
-Update specified tool or all tools to the latest version and update `mops.toml`
+Update tools already pinned in `[toolchain]` to the latest version and update `mops.toml`
 
 ```
 mops toolchain update [tool]
 ```
 
+Only tools present in the `[toolchain]` section of `mops.toml` are updated. Without an argument, every pinned tool is updated; with an argument, the command fails if that tool is not pinned yet — use [`mops toolchain use`](./03-mops-toolchain-use.md) for a first pin.
+
 ## Examples
 
-Update all tools to the latest version
+Update all pinned tools to the latest version
 ```
 mops toolchain update
 ```
@@ -24,4 +26,5 @@ mops toolchain update moc
 mops toolchain update wasmtime
 mops toolchain update pocket-ic
 mops toolchain update lintoko
+mops toolchain update wasm-opt
 ```

--- a/docs/docs/cli/5-toolchain/07-mops-toolchain-info.md
+++ b/docs/docs/cli/5-toolchain/07-mops-toolchain-info.md
@@ -11,7 +11,7 @@ Show release information about a toolchain tool from GitHub.
 mops toolchain info <tool>
 ```
 
-`<tool>` is one of `moc`, `lintoko`, `wasmtime`, or `pocket-ic`.
+`<tool>` is one of `moc`, `lintoko`, `wasmtime`, `pocket-ic`, or `wasm-opt`.
 
 Works without a `mops.toml` — useful for scripts that warm tool caches.
 

--- a/docs/docs/cli/7-misc/06-environment-variables.md
+++ b/docs/docs/cli/7-misc/06-environment-variables.md
@@ -20,6 +20,30 @@ export MOPS_NETWORK="local"
 mops install
 ```
 
+## Project Environment
+
+### `MOPS_ENV`
+
+Expanded into local `path` dependencies that contain the `{MOPS_ENV}` placeholder (defaults to `local` when unset):
+
+```toml
+[dependencies]
+envdep = "./envs/{MOPS_ENV}/dep"
+```
+
+```bash
+export MOPS_ENV="staging"
+mops install
+```
+
+### `MOPS_CWD`
+
+Change the working directory before the command runs. Useful for npm scripts, where npm sets the working directory to the package root:
+
+```bash
+MOPS_CWD="canisters/backend" mops install
+```
+
 ## Registry Configuration
 
 ### `MOPS_REGISTRY_HOST`

--- a/docs/versioned_docs/version-2.x/09-mops.toml.md
+++ b/docs/versioned_docs/version-2.x/09-mops.toml.md
@@ -188,7 +188,7 @@ Global build settings used by [`mops build`](./cli/4-dev/03-mops-build.md).
 | outputDir | Output directory for compiled Wasm and Candid files (default `.mops/.build`). Path is relative to `mops.toml`. The `--output` CLI flag takes precedence. |
 | args      | Array of flags passed to `moc` for every canister build (e.g. `["--release", "--ai-errors"]`) |
 | check-wasm | Analyze each final Wasm for likely IC0505 function-complexity risks without starting PocketIC (default `false`). Override for one build with `--check-wasm` or `--no-check-wasm`. |
-| check-deploy | Install every built Wasm on a fresh PocketIC canister and fail on deployment or initialization errors (default `false`). Requires `pocket-ic` 9.0.0 or newer in `[toolchain]`. Before installation, Mops runs `moc --stable-compatible` from a temporary empty-actor `.most` to each generated `.most`. Incompatible canisters are skipped with `MOPS-CHECK-DEPLOY-SKIPPED`; eligible siblings are still checked. Override for one build with `--check-deploy` or `--no-check-deploy`. |
+| check-deploy | Install every built Wasm on a fresh PocketIC canister and fail on deployment or initialization errors (default `false`). Requires `pocket-ic` 9.0.0 or newer in `[toolchain]`, unless `MOPS_POCKET_IC_URL` points at an already-running PocketIC server. Before installation, Mops runs `moc --stable-compatible` from a temporary empty-actor `.most` to each generated `.most`. Incompatible canisters are skipped with `MOPS-CHECK-DEPLOY-SKIPPED`; eligible siblings are still checked. Override for one build with `--check-deploy` or `--no-check-deploy`. |
 
 Example:
 ```toml

--- a/docs/versioned_docs/version-2.x/cli/2-publish/05-mops-owner.md
+++ b/docs/versioned_docs/version-2.x/cli/2-publish/05-mops-owner.md
@@ -32,6 +32,13 @@ Remove package owner.
 mops owner remove <principal>
 ```
 
+### `--yes`
+
+`mops owner add` and `mops owner remove` ask for confirmation. Pass `--yes` to skip the prompt (required in non-interactive environments like CI):
+```
+mops owner add <principal> --yes
+```
+
 ## Example
 
 Imagine you have a package named `hello` and you want to add the principal `2d2zu-vaaaa-aaaak-qb6pq-cai` as an owner.

--- a/docs/versioned_docs/version-2.x/cli/2-publish/06-mops-maintainer.md
+++ b/docs/versioned_docs/version-2.x/cli/2-publish/06-mops-maintainer.md
@@ -32,6 +32,13 @@ Remove package maintainer.
 mops maintainer remove <principal>
 ```
 
+### `--yes`
+
+`mops maintainer add` and `mops maintainer remove` ask for confirmation. Pass `--yes` to skip the prompt (required in non-interactive environments like CI):
+```
+mops maintainer add <principal> --yes
+```
+
 ## Example
 
 Imagine you have a package named `hello` and you want to add the principal `2d2zu-vaaaa-aaaak-qb6pq-cai` as a maintainer.

--- a/docs/versioned_docs/version-2.x/cli/3-user/01-mops-user-import.md
+++ b/docs/versioned_docs/version-2.x/cli/3-user/01-mops-user-import.md
@@ -19,6 +19,14 @@ This command accepts PEM file contents, not a path to a file.
 
 Supported keys are secp256k1 and Ed25519, in SEC1 (`-----BEGIN EC PRIVATE KEY-----`) or PKCS#8 (`-----BEGIN PRIVATE KEY-----`) format. This covers identities exported by `dfx` and `icp-cli`.
 
+### `--no-encrypt`
+
+Do not ask for a password to encrypt the identity. The identity is stored unencrypted, so commands that use it never prompt for a password — useful in CI and scripts.
+
+```
+mops user import --no-encrypt -- <pem_data>
+```
+
 ### Import identity from DFX
 
 ```

--- a/docs/versioned_docs/version-2.x/cli/4-dev/01-mops-test.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/01-mops-test.md
@@ -10,7 +10,14 @@ Mops can run Motoko unit tests
 mops test
 ```
 
-Put your tests in `test/*.test.mo` files.
+Put your tests in `*.test.mo` files inside a `test/` or `tests/` directory (nested subdirectories work too).
+
+If a `test/lib.mo` (or `tests/lib.mo`) file exists, it is the **only** file run — use it as an entry point that imports your other tests.
+
+Pass a filter to run a subset of files — `mops test nat` runs every `*nat*.mo` file under the test directory (the `.test.mo` suffix is not required for filtered files):
+```
+mops test nat
+```
 
 All tests run as quickly as possible thanks to parallel execution.
 
@@ -60,12 +67,16 @@ Available modes:
 
 - `interpreter` - run tests via `moc -r` (default)
 - `wasi` - compile test file to wasm and execute it with `wasmtime`. Useful, when you use `to_candid`/`from_candid`, or if you get stackoverflow errors.
+- `replica` - deploy test files as canisters to a local replica ([`--replica`](#--replica) selects which one). See [Replica tests](#replica-tests).
 
 
-You can also specify `wasi` mode for a specific test file by adding the line below as the first line in the test file
+You can also specify `wasi` or `replica` mode for a specific test file by adding one of these markers to the file (on a line of its own, with nothing else on the line):
 ```
 // @testmode wasi
+// @testmode replica
 ```
+
+Test files that define an actor run in `replica` mode automatically.
 
 ### `--replica`
 
@@ -128,8 +139,6 @@ actor {
   };
 };
 ```
-
-Make sure your actor doesn't have a name `actor {`.
 
 Make sure your actor has `runTests` method.
 

--- a/docs/versioned_docs/version-2.x/cli/4-dev/02-mops-bench.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/02-mops-bench.md
@@ -11,7 +11,7 @@ Run Motoko benchmarks.
 mops bench [filter]
 ```
 
-Put your benchmark code in `bench/*.bench.mo` files.
+Put your benchmark code in `*.bench.mo` files inside a `bench/` or `benchmark/` directory (nested subdirectories work too). With a `[filter]` argument, every `*<filter>*.mo` file under those directories runs — the `.bench.mo` suffix is not required for filtered files.
 
 It is necessary to use [bench package](https://mops.one/bench) to write benchmarks.
 

--- a/docs/versioned_docs/version-2.x/cli/4-dev/03-mops-build.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/03-mops-build.md
@@ -125,6 +125,8 @@ check-deploy = true
 
 PocketIC 9.0.0 or newer, or a local PocketIC binary path, must be pinned in
 `[toolchain]`. Mops cannot verify compatibility for a path pin.
+Set `MOPS_POCKET_IC_URL` to use an already-running PocketIC server instead;
+the pin is then ignored.
 ```toml
 [toolchain]
 pocket-ic = "15.0.0"
@@ -173,6 +175,8 @@ Each canister configuration supports:
 - `args` - Additional compiler arguments for this specific canister (optional)
 - `initArg` - Candid-encoded initialization arguments (optional)
 - `candid` - Path to the Candid interface file (optional, for compatibility checking)
+- `wasmMemoryLimit` - Wasm memory limit in bytes applied by [`--check-deploy`](#--check-deploy) (optional)
+- `[canisters.<name>.migrations]` and `[canisters.<name>.check-stable]` subtables — see the [`mops.toml` reference](../../09-mops.toml.md#canisters)
 
 You can also set global build settings:
 ```toml

--- a/docs/versioned_docs/version-2.x/cli/4-dev/mops-docs/41-mops-docs-generate.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/mops-docs/41-mops-docs-generate.md
@@ -15,7 +15,7 @@ mops docs generate [options]
 ## Options
 
 - `--source <source>` - Source directory containing .mo files (default: `src`)
-- `--output <output>` - Output directory for generated documentation (default: `docs`)
+- `--output <output>`, `-o` - Output directory for generated documentation (default: `docs`)
 - `--format <format>` - Output format: `md`, `adoc`, or `html` (default: `md`)
 
 ## Description

--- a/docs/versioned_docs/version-2.x/cli/5-toolchain/01-toolchain-overview.md
+++ b/docs/versioned_docs/version-2.x/cli/5-toolchain/01-toolchain-overview.md
@@ -22,8 +22,8 @@ When you run `mops install` command, Mops will install the specified version of 
 
 You can use [`mops toolchain use`](./03-mops-toolchain-use.md) command to install specific tool version and update `mops.toml` file.
 ```
-mops toolchain use moc 0.10.3
-mops toolchain use wasmtime 16.0.0
+mops toolchain use moc 1.0.0
+mops toolchain use wasmtime 41.0.0
 mops toolchain use pocket-ic 15.0.0
 mops toolchain use lintoko 0.7.0
 mops toolchain use wasm-opt 131
@@ -37,8 +37,8 @@ You can manually edit `mops.toml` file to specify exact versions of each tool.
 
 ```toml
 [toolchain]
-moc = "0.10.3"
-wasmtime = "16.0.0"
+moc = "1.0.0"
+wasmtime = "41.0.0"
 lintoko = "0.7.0"
 pocket-ic = "15.0.0"
 wasm-opt = "131"

--- a/docs/versioned_docs/version-2.x/cli/5-toolchain/03-mops-toolchain-use.md
+++ b/docs/versioned_docs/version-2.x/cli/5-toolchain/03-mops-toolchain-use.md
@@ -15,9 +15,9 @@ mops toolchain use <tool> [version]
 
 Install specific tool version
 ```
-mops toolchain use moc 0.10.3
-mops toolchain use wasmtime 16.0.0
-mops toolchain use pocket-ic 1.0.0
+mops toolchain use moc 1.0.0
+mops toolchain use wasmtime 41.0.0
+mops toolchain use pocket-ic 15.0.0
 mops toolchain use lintoko 0.7.0
 ```
 

--- a/docs/versioned_docs/version-2.x/cli/5-toolchain/04-mops-toolchain-update.md
+++ b/docs/versioned_docs/version-2.x/cli/5-toolchain/04-mops-toolchain-update.md
@@ -5,15 +5,17 @@ sidebar_label: mops toolchain update
 
 # `mops toolchain update`
 
-Update specified tool or all tools to the latest version and update `mops.toml`
+Update tools already pinned in `[toolchain]` to the latest version and update `mops.toml`
 
 ```
 mops toolchain update [tool]
 ```
 
+Only tools present in the `[toolchain]` section of `mops.toml` are updated. Without an argument, every pinned tool is updated; with an argument, the command fails if that tool is not pinned yet — use [`mops toolchain use`](./03-mops-toolchain-use.md) for a first pin.
+
 ## Examples
 
-Update all tools to the latest version
+Update all pinned tools to the latest version
 ```
 mops toolchain update
 ```
@@ -24,4 +26,5 @@ mops toolchain update moc
 mops toolchain update wasmtime
 mops toolchain update pocket-ic
 mops toolchain update lintoko
+mops toolchain update wasm-opt
 ```

--- a/docs/versioned_docs/version-2.x/cli/5-toolchain/07-mops-toolchain-info.md
+++ b/docs/versioned_docs/version-2.x/cli/5-toolchain/07-mops-toolchain-info.md
@@ -11,7 +11,7 @@ Show release information about a toolchain tool from GitHub.
 mops toolchain info <tool>
 ```
 
-`<tool>` is one of `moc`, `lintoko`, `wasmtime`, or `pocket-ic`.
+`<tool>` is one of `moc`, `lintoko`, `wasmtime`, `pocket-ic`, or `wasm-opt`.
 
 Works without a `mops.toml` — useful for scripts that warm tool caches.
 

--- a/docs/versioned_docs/version-2.x/cli/7-misc/06-environment-variables.md
+++ b/docs/versioned_docs/version-2.x/cli/7-misc/06-environment-variables.md
@@ -20,6 +20,30 @@ export MOPS_NETWORK="local"
 mops install
 ```
 
+## Project Environment
+
+### `MOPS_ENV`
+
+Expanded into local `path` dependencies that contain the `{MOPS_ENV}` placeholder (defaults to `local` when unset):
+
+```toml
+[dependencies]
+envdep = "./envs/{MOPS_ENV}/dep"
+```
+
+```bash
+export MOPS_ENV="staging"
+mops install
+```
+
+### `MOPS_CWD`
+
+Change the working directory before the command runs. Useful for npm scripts, where npm sets the working directory to the package root:
+
+```bash
+MOPS_CWD="canisters/backend" mops install
+```
+
 ## Registry Configuration
 
 ### `MOPS_REGISTRY_HOST`


### PR DESCRIPTION
The 2.x CLI docs contradicted actual CLI behavior in nine places — missing test/bench discovery rules, an undocumented test mode, undocumented flags and environment variables, and stale toolchain versions. Each defect was found by the v3 docs audit (branch `kamil-claude/v3-sync-2x-docs`) and re-verified here against the 2.x source (`cli/cli.ts`, `cli/commands/**`) before porting, since 2.x behavior sometimes differs from v3.

## What was wrong

- **mops test**: the mode list omitted `replica` (the CLI accepts `interpreter|wasi|replica`); the `// @testmode` block showed only `wasi` and claimed the marker must be the first line — it is an exact full-line match anywhere in the file (`lines.includes(...)` in `test/test.ts`); "Make sure your actor doesn't have a name" contradicts the detection regex `/^(persistent )?actor( class)?/`, which matches named actors too; discovery was described as "test/*.test.mo" but is `**/test?(s)/**/*.test.mo` with a `test/lib.mo` short-circuit and a `[filter]` that widens the glob to `*<filter>*.mo`.
- **mops bench**: discovery is `**/bench?(mark)/**/*.bench.mo` with the same filter widening — the page said only "bench/*.bench.mo".
- **mops owner / maintainer**: `--yes` undocumented.
- **mops user import**: `--no-encrypt` undocumented.
- **Environment variables**: `MOPS_ENV` (expands `{MOPS_ENV}` in path dependencies, defaults to `local`) and `MOPS_CWD` (chdir before the command runs, for npm scripts) undocumented.
- **mops docs generate**: the `-o` short alias undocumented.
- **mops toolchain info / update**: both accept `wasm-opt` (it is in `TOOLCHAINS`), and `update <tool>` errors when the tool is not pinned in `[toolchain]` — verified in `commands/toolchain/index.ts`. The pages implied a four-tool list and unconditional updates.
- **mops build**: the "Each canister configuration supports" list omitted `wasmMemoryLimit` (used in an example on the same page) and the `migrations`/`check-stable` subtables.
- **Toolchain overview / use**: stale example versions `moc 0.10.3` / `wasmtime 16.0.0` (and `pocket-ic 1.0.0` in `use`) → `1.0.0` / `41.0.0` / `15.0.0`, matching `09-mops.toml.md`.

## Deviations from the v3 wording

- The `replica` mode bullet is worded replica-neutrally — 2.x still has the deprecated dfx path selected via `--replica`, so the v3 "PocketIC replica" phrasing would be wrong here.
- The v3 `MOPS_ENV` note about lockfile staleness is not ported — it describes v3-only lockfile behavior and links a v3-only anchor.
- The v3 missing-blank-line fix in mops-build does not apply — 2.x has no `--locked` section on that page and the blank line is already present.

## Tree sync

`docs/docs/` and `docs/versioned_docs/version-2.x/` must be byte-identical (AGENTS.md). Besides applying every fix to both trees, this also carries [#761](https://github.com/caffeinelabs/mops/pull/761)'s `MOPS_POCKET_IC_URL` wording into `versioned_docs` (`09-mops.toml.md`, `cli/4-dev/03-mops-build.md`), where it had only landed in `docs/docs/`. `diff -r docs/docs docs/versioned_docs/version-2.x` is now empty, and `cd docs && npm run build` passes (Docusaurus validates links and anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
