### PR TITLE
fix(cli): disable `moc --stable-baseline` until the moc bug is fixed

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -128,7 +128,7 @@ Adding a package that is already declared in the other section **moves** it rath
 
 Primary correctness command — runs moc check, then check-stable (if configured), then lint (if lintoko is in toolchain).
 
-On moc 1.12.0+, canisters with `[migrations]` get stricter upgrade diagnostics: a field the initial actor requires that no migration produces fails as an `M0267` error instead of only warning (`M0254`), and compat errors carry a source location. Older moc pins and canisters without `[migrations]` are unaffected.
+On moc 1.12.0+, canisters with `[migrations]` get stricter upgrade diagnostics: a field the initial actor requires that no migration produces fails as an `M0267` error instead of only warning (`M0254`), and compat errors carry a source location. **Temporarily disabled** — `moc --stable-baseline` is buggy, so every pin runs the pre-1.12.0 check. Older moc pins and canisters without `[migrations]` are unaffected either way.
 
 The `check-stable` baseline is always a `.most` file — as `[canisters.<name>.check-stable].path` or as the `mops check-stable <baseline.most>` argument. A `.mo` source is rejected. See [`mops deployed`](#mops-deployed) for where the baseline comes from — that differs between a fresh project and an already-deployed canister.
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- Temporarily disabled `--stable-baseline` in `mops check` and `mops check-stable` due to a `moc` bug. Upgrade compatibility is still checked, but the moc 1.12.0+ diagnostics are off until moc ships a fix.
 - Node.js >= 22 is now required (`engines` bump from >= 20). Node 20 reached end of life on 2026-04-30, and nothing in the project tested against it — CI runs on 22, 24 and 26, and release builds run on Node 24 — so `>= 20` was a support claim with nothing behind it. Node 22 is in LTS maintenance until April 2027. The prerequisite lists in the README, the CLI README, the quick-start guide and `cli/DEVELOPMENT.md` are updated to match.
 
 ## 3.0.0

--- a/cli/commands/check-stable.ts
+++ b/cli/commands/check-stable.ts
@@ -35,8 +35,16 @@ function hasEnhancedMigrationArg(args: string[]): boolean {
   );
 }
 
+// TEMPORARY: `moc --stable-baseline` is buggy, so no pin folds the upgrade check
+// into `moc --check` — everything takes the 3-invocation path. Drop this constant
+// and the guard below once moc ships the fix.
+const STABLE_BASELINE_DISABLED = true;
+
 /** moc 1.12.0+: one `moc --check --stable-baseline` instead of 3 invocations. */
 export function canUseStableBaselineCheck(canisterArgs: string[]): boolean {
+  if (STABLE_BASELINE_DISABLED) {
+    return false;
+  }
   return supportsStableBaselineCheck() && hasEnhancedMigrationArg(canisterArgs);
 }
 

--- a/cli/tests/__snapshots__/migrate.test.ts.snap
+++ b/cli/tests/__snapshots__/migrate.test.ts.snap
@@ -53,10 +53,8 @@ exports[`migrate check check fails without next migration, passes with it 1`] = 
   "exitCode": 1,
   "stderr": "src/main.mo:3.1-11.2: Compatibility error [M0169], stable variable \`a\` of version \`20250301_000000_AddEmail\` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-src/main.mo:4.7-4.9: type error [M0267], initial actor requires field \`id\` of type
-  Nat; not found in the previous version — write a migration that produces it
-src/main.mo:3.1-11.2: Compatibility error [M0169], stable variable \`a\` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+migrations/20250101_000000_Init.mo:0.1: warning [M0254], initial actor requires field \`id\` of type
+  Nat
 ✗ Check failed for canister backend (exit code: 1)",
   "stdout": "",
 }
@@ -78,8 +76,12 @@ exports[`migrate check check with trimming shows reduced chain 1`] = `
   "stdout": "check Using --all-libs for richer diagnostics
 migrations Prepared 2 migration(s) for backend (trimmed from 3)
 check Checking canister backend:
-<CACHE><MOC> ["src/main.mo","--check","--all-libs","--stable-baseline","deployed.most","--default-persistent-actors","--enhanced-migration=.migrations-backend","-A=M0254"]
+<CACHE><MOC> ["src/main.mo","--check","--all-libs","--default-persistent-actors","--enhanced-migration=.migrations-backend","-A=M0254"]
 ✓ backend
+check-stable Generating stable types for src/main.mo
+<CACHE><MOC> ["--stable-types","-o",".mops/.check-stable/new.wasm","src/main.mo","--default-persistent-actors","--enhanced-migration=.migrations-backend","-A=M0254"]
+check-stable Comparing deployed.most ↔ .mops/.check-stable/new.most
+<CACHE><MOC> ["--stable-compatible","deployed.most",".mops/.check-stable/new.most"]
 ✓ Stable compatibility check passed for canister 'backend'",
 }
 `;
@@ -145,11 +147,11 @@ exports[`migrate migrate new creates a migration file with timestamp and templat
 exports[`migrate stable check stable check fails when deployed.most is incompatible 1`] = `
 {
   "exitCode": 1,
-  "stderr": "src/main.mo:3.1-11.2: Compatibility error [M0169], stable variable \`a\` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+  "stderr": "(unknown location): Compatibility error [M0169], stable variable \`a\` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-src/main.mo:3.1-11.2: Compatibility error [M0169], stable variable \`name\` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+(unknown location): Compatibility error [M0169], stable variable \`name\` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-✗ Check failed for canister backend (exit code: 1)",
-  "stdout": "",
+✗ Stable compatibility check failed for canister 'backend'",
+  "stdout": "✓ backend",
 }
 `;

--- a/cli/tests/check-stable.test.ts
+++ b/cli/tests/check-stable.test.ts
@@ -27,14 +27,16 @@ describe("check-stable", () => {
     expect(result.stdout).toMatch(/Stable compatibility check passed/);
   });
 
-  // Fixture pinned to moc 1.12.0 — EM + `.most` baseline folds into one invocation.
-  test("moc 1.12+ EM checks the baseline in a single moc invocation", async () => {
+  // Fixture pinned to moc 1.12.0 — EM + `.most` baseline would fold into one
+  // invocation, but `--stable-baseline` is disabled while moc's bug is open.
+  // Flip this back to asserting the fold when `STABLE_BASELINE_DISABLED` goes.
+  test("moc 1.12+ EM keeps the classic path while --stable-baseline is off", async () => {
     const cwd = path.join(import.meta.dirname, "check-stable/migrations-chain");
     const result = await cli(["check-stable", "--verbose"], { cwd });
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toMatch(/--stable-baseline/);
-    expect(result.stdout).not.toMatch(/--stable-compatible/);
-    expect(result.stdout).not.toMatch(/Generating stable types for/);
+    expect(result.stdout).not.toMatch(/--stable-baseline/);
+    expect(result.stdout).toMatch(/--stable-compatible/);
+    expect(result.stdout).toMatch(/Generating stable types for/);
     expect(result.stdout).toMatch(/Stable compatibility check passed/);
   });
 

--- a/cli/tests/check.test.ts
+++ b/cli/tests/check.test.ts
@@ -115,6 +115,7 @@ describe("check", () => {
 
   // Fixture pinned to moc 1.12.0: folding needs --enhanced-migration, so a
   // non-EM canister keeps the classic path even on a moc that supports it.
+  // (`--stable-baseline` is disabled outright for now, so this also holds for EM.)
   test("deployed: non-EM canister does not fold into --stable-baseline", async () => {
     const cwd = path.join(import.meta.dirname, "check/deployed-compatible");
     const result = await cli(["check", "--verbose"], { cwd });

--- a/docs/docs/cli/4-dev/04-mops-check.md
+++ b/docs/docs/cli/4-dev/04-mops-check.md
@@ -134,7 +134,7 @@ If the file at `path` doesn't exist, the check fails with an error. For initial 
 actor { };
 ```
 
-On `moc` 1.12.0+, canisters with `[migrations]` configured and a `.most` baseline get better upgrade diagnostics — see [diagnostics on moc 1.12.0+](./05-mops-check-stable.md#diagnostics-on-moc-1120).
+On `moc` 1.12.0+, canisters with `[migrations]` configured and a `.most` baseline get better upgrade diagnostics — currently disabled while a `moc` bug is open, see [diagnostics on moc 1.12.0+](./05-mops-check-stable.md#diagnostics-on-moc-1120).
 
 For more details, see [`mops check-stable`](./05-mops-check-stable.md).
 

--- a/docs/docs/cli/4-dev/05-mops-check-stable.md
+++ b/docs/docs/cli/4-dev/05-mops-check-stable.md
@@ -100,13 +100,17 @@ Require an up-to-date [`mops.lock`](../../10-mops.lock.md) and never write it �
 
 When `[canisters.<name>.migrations].check-limit` is set, `mops check-stable` compares the deployed `.most` baseline against the local chain after the compatibility check. If more migrations are pending than `check-limit` allows, mops reports a diagnostic naming the latest pending file to fold into. If compat already failed, this replaces the misleading `moc` error (trimming started from the wrong state). If compat passed anyway, it is shown as a warning.
 
-On `moc` 1.12.0+ this diagnostic can also replace type errors from the same run. The command still exits non-zero; fold the pending migrations (or pass `--no-check-limit`) to see them.
+On `moc` 1.12.0+ this diagnostic can also replace type errors from the same run. The command still exits non-zero; fold the pending migrations (or pass `--no-check-limit`) to see them. (Currently inactive — see [diagnostics on moc 1.12.0+](#diagnostics-on-moc-1120).)
 
 ## Enhanced migration support
 
 When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops check-stable` automatically injects the `--enhanced-migration` flag when generating stable type signatures.
 
 ## Diagnostics on moc 1.12.0+
+
+:::warning Temporarily disabled
+These improvements are turned off in the current release. `moc`'s `--stable-baseline` has a bug, so every `moc` pin runs the check the pre-1.12.0 way until `moc` ships a fix — the check still runs and still fails on an incompatible upgrade, but the diagnostics below are not in effect.
+:::
 
 On `moc` 1.12.0 or newer, two diagnostics improve for canisters that have `[migrations]` configured:
 

--- a/docs/docs/cli/4-dev/08-mops-migrate.md
+++ b/docs/docs/cli/4-dev/08-mops-migrate.md
@@ -93,6 +93,6 @@ The limits count the full virtual chain (frozen + pending next migration). This 
 
 Already-applied migrations are skipped at runtime by the Motoko RTS, so trimming is safe. When trimming is active, M0254 warnings are automatically suppressed.
 
-On moc 1.12.0+ that suppression covers fields the deployed `.most` baseline already provides — the normal trimming case. A field that the baseline does not provide and no migration in the chain produces fails as an M0267 error instead of warning. See [diagnostics on moc 1.12.0+](./05-mops-check-stable.md#diagnostics-on-moc-1120).
+On moc 1.12.0+ that suppression covers fields the deployed `.most` baseline already provides — the normal trimming case. A field that the baseline does not provide and no migration in the chain produces fails as an M0267 error instead of warning. This is currently disabled while a `moc` bug is open, so every pin warns — see [diagnostics on moc 1.12.0+](./05-mops-check-stable.md#diagnostics-on-moc-1120).
 
 When `check-limit` is set, `mops check-stable` (and the stable check inside `mops check`) compares the deployed `.most` baseline against the local chain after the compatibility check. If more migrations are pending than `check-limit` allows, mops reports a diagnostic suggesting to fold all changes into the latest pending migration. If compat already failed, this replaces the misleading `moc` error; if compat passed anyway, it is shown as a warning. Only runs when `check-limit` is configured.


### PR DESCRIPTION
`moc --stable-baseline` is buggy, so `mops check` and `mops check-stable` stop folding the upgrade-compatibility check into `moc --check`. Every `moc` pin is back on the three-step path (`--stable-types`, then `--stable-compatible`) — the same path pins below 1.12.0 and canisters without `[migrations]` already took. The check still runs and still fails on an incompatible upgrade; only the number of `moc` invocations and the quality of two diagnostics change.

The switch is one constant, so re-enabling is deleting it and the guard under it:

```ts
const STABLE_BASELINE_DISABLED = true;

export function canUseStableBaselineCheck(canisterArgs: string[]): boolean {
  if (STABLE_BASELINE_DISABLED) {
    return false;
  }
  return supportsStableBaselineCheck() && hasEnhancedMigrationArg(canisterArgs);
}
```

## What users see

Two diagnostics revert with the fold, for canisters with `[migrations]` and a committed `.most` baseline. Compatibility errors lose their source span:

Before:

```
src/main.mo:3.1-11.2: Compatibility error [M0169], stable variable `a` of the previous version cannot be implicitly discarded.
```

After:

```
(unknown location): Compatibility error [M0169], stable variable `a` of the previous version cannot be implicitly discarded.
```

And a field the initial actor requires that no migration produces goes back to warning instead of failing:

Before:

```
src/main.mo:4.7-4.9: type error [M0267], initial actor requires field `id` of type
  Nat; not found in the previous version — write a migration that produces it
```

After:

```
migrations/20250101_000000_Init.mo:0.1: warning [M0254], initial actor requires field `id` of type
  Nat
```

That second one is a real loss of strictness: a forgotten migration that 2.23.0+ failed on will pass again with a warning until `moc` is fixed. Nothing else about the compatibility verdict moves — `mops check --verbose` now shows `--stable-types` / `--stable-compatible` where it showed `--stable-baseline`, and the scratch `.mops/.check-stable-*` dir is back.

## What is unchanged

- `-A=M0254` suppression under [chain trimming](https://docs.mops.one/cli/dev/mops-migrate#chain-trimming) — that never went through the fold.
- The pending-migration `check-limit` diagnostic, which both paths already report.
- The `.most`-only baseline requirement from [#758](https://github.com/ZenVoich/mops/pull/758).
- `MOC_STABLE_BASELINE_MIN_VERSION` and the version gate itself, kept intact so the revert is mechanical.

## Docs

The "Diagnostics on moc 1.12.0+" section is annotated as temporarily disabled rather than deleted, with pointers from `mops check` and `mops migrate` — same reasoning: the revert should be removing a note, not rewriting prose.

Follow-up: re-enable once `moc` ships the fix, and flip the `check-stable` test back to asserting the single invocation (the test comment says so at the assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
