### PR TITLE
fix(ci): bump the cli canister assetstorage wasm to 0.32.0

### DIFF
--- a/icp.yaml
+++ b/icp.yaml
@@ -72,8 +72,11 @@ canisters:
           commands:
             - npm run build-cli-releases
         - type: pre-built
-          url: https://github.com/dfinity/sdk/releases/download/0.29.1/assetstorage.wasm.gz
-          sha256: 4014793c83ae0ff2d851a0c4e62f289a114d36bc1826f5579f55a70ff3c70551
+          # 0.32.0 is the version the sync plugin below requires: its `list`
+          # pagination loop never terminates against pre-0.30.1 assetstorage,
+          # which ignores `start`/`length` and returns every asset each call.
+          url: https://github.com/dfinity/sdk/releases/download/0.32.0/assetstorage.wasm.gz
+          sha256: 04e565b3425fe7510ee16b02adcfe3f01abc9a2725c82a21cb08969241debd62
     sync:
       steps:
         - type: plugin

--- a/icp.yaml
+++ b/icp.yaml
@@ -26,7 +26,9 @@ canisters:
       type: "@dfinity/asset-canister@v2.3.0"
       sha256: ee41744bd1361593a041d830b06ce50598cae5b21b57209fc727e8f63ae7e906
       configuration:
-        version: "0.29.1"
+        # 0.32.0 is what the recipe's bundled sync plugin requires — see the
+        # matching note on the `cli` canister below.
+        version: "0.32.0"
         dir: frontend/dist
         build:
           - npm run build-frontend
@@ -47,7 +49,7 @@ canisters:
       type: "@dfinity/asset-canister@v2.3.0"
       sha256: ee41744bd1361593a041d830b06ce50598cae5b21b57209fc727e8f63ae7e906
       configuration:
-        version: "0.29.1"
+        version: "0.32.0"
         dir: blog/build
         build:
           - npm run build-blog
@@ -58,7 +60,7 @@ canisters:
       type: "@dfinity/asset-canister@v2.3.0"
       sha256: ee41744bd1361593a041d830b06ce50598cae5b21b57209fc727e8f63ae7e906
       configuration:
-        version: "0.29.1"
+        version: "0.32.0"
         dir: play-frontend
   # Raw build/sync (not the recipe) because the asset-canister recipe template
   # only supports a single `dir`, and `cli` serves two: `cli-releases/`


### PR DESCRIPTION
Deploying the `cli` canister hangs forever in the asset sync step. The pinned sync plugin (`certified-assets` `migration-v2.2.1`) pages through the canister's `list` method until it sees an empty or shrinking page — but the pinned dfx 0.29.1 `assetstorage.wasm` predates `list` pagination (added in SDK 0.30.1): it ignores `start`/`length` and returns every asset on every call, so the paging loop never terminates. Verified against production: `list (record { start = opt 999999; length = opt 3 })` returns all 126 assets, identical to `start = 0`.

The bug evades the plugin's own guard because the guard checks `api_version >= 2`, which 0.29.1 already reports — the plugin states it requires the dfx 0.32.0 assetstorage, so that is what this pins (state survives the upgrade; it is the asset canister's normal supported upgrade path). It also went undetected in every release before v3.0.0: the icp deploy path for `cli` first ran on the v3.0.0 tag — v2.24.0 and earlier still deployed via dfx, whose `ic-asset` handles non-paginating canisters.

The same trap exists in the `@dfinity/asset-canister@v2.3.0` recipe used by `assets`, `blog`, and `play-frontend`: it bundles the identical sync plugin (same sha256) and installs whatever assetstorage `version` it is configured with — and `assets`/`blog` run 0.29.1 on mainnet today. Their deploys are manual-only, so nothing is failing yet; the `version` bumps here remove the trap before the next manual deploy. All three are small (1.6–21 MB), so the upgrades carry no reserved-cycles risk.

Production `cli` is already running 0.32.0 — the fix was applied out-of-band on 2026-08-20 to recover the v3.0.0/v3.1.0 releases, whose deploy step had separately failed on the subnet's reserved-cycles limit (raised to 25T on the canister as part of the same recovery). This PR records the deployed reality in `icp.yaml`.

## Follow-up worth flagging

- The infinite loop is worth an upstream issue on [dfinity/certified-assets](https://github.com/dfinity/certified-assets): the `api_version` guard does not reject non-paginating canisters, and the failure mode is a silent hang.
- The release artifacts for v3.0.0/v3.1.0 (deployed to cli.mops.one during the recovery) come in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)