### PR TITLE
test(cli): cover the `--stable-baseline` trimmed-baseline regression

### DIFF
--- a/cli/commands/check-stable.ts
+++ b/cli/commands/check-stable.ts
@@ -18,7 +18,10 @@ import {
   resolveSingleCanister,
   validateCanisterArgs,
 } from "../helpers/resolve-canisters.js";
-import { supportsStableBaselineCheck } from "../helpers/get-moc-version.js";
+import {
+  hasStableBaselineFix,
+  supportsStableBaselineCheck,
+} from "../helpers/get-moc-version.js";
 import { sourcesArgs } from "./sources.js";
 import { toolchain } from "./toolchain/index.js";
 
@@ -35,17 +38,13 @@ function hasEnhancedMigrationArg(args: string[]): boolean {
   );
 }
 
-// TEMPORARY: `moc --stable-baseline` is buggy, so no pin folds the upgrade check
-// into `moc --check` — everything takes the 3-invocation path. Drop this constant
-// and the guard below once moc ships the fix.
-const STABLE_BASELINE_DISABLED = true;
-
-/** moc 1.12.0+: one `moc --check --stable-baseline` instead of 3 invocations. */
+/** moc 1.12.0+ with the `--stable-baseline` fix: one `moc --check` instead of 3. */
 export function canUseStableBaselineCheck(canisterArgs: string[]): boolean {
-  if (STABLE_BASELINE_DISABLED) {
-    return false;
-  }
-  return supportsStableBaselineCheck() && hasEnhancedMigrationArg(canisterArgs);
+  return (
+    supportsStableBaselineCheck() &&
+    hasStableBaselineFix() &&
+    hasEnhancedMigrationArg(canisterArgs)
+  );
 }
 
 export interface CheckStableOptions {

--- a/cli/helpers/get-moc-version.ts
+++ b/cli/helpers/get-moc-version.ts
@@ -20,6 +20,18 @@ export function getMocVersion(): string {
 /** First moc that runs the upgrade check inside `moc --check --stable-baseline`. */
 export const MOC_STABLE_BASELINE_MIN_VERSION = "1.12.0";
 
+// `--stable-baseline` mis-handles a baseline that already contains a migration
+// `check-limit` trimmed away: moc demands a field that migration dropped and fails
+// a valid upgrade (M0267). Every released moc that accepts the flag has this, so the
+// fold is opt-in per build; collapse this into a version floor once the fix ships.
+const MOC_STABLE_BASELINE_FIXED_VERSIONS = new Set([
+  "1.14.1-fix-stable-baseline",
+]);
+
+export function hasStableBaselineFix(): boolean {
+  return MOC_STABLE_BASELINE_FIXED_VERSIONS.has(getMocVersion());
+}
+
 export function supportsStableBaselineCheck(): boolean {
   const version = getMocSemVer();
   return version

--- a/cli/tests/check-stable.test.ts
+++ b/cli/tests/check-stable.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "@jest/globals";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import path from "path";
-import { cli, cliSnapshot } from "./helpers";
+import { cli, cliSnapshot, useTempFixtures } from "./helpers";
 
 describe("check-stable", () => {
   test("compatible upgrade", async () => {
@@ -27,10 +28,9 @@ describe("check-stable", () => {
     expect(result.stdout).toMatch(/Stable compatibility check passed/);
   });
 
-  // Fixture pinned to moc 1.12.0 — EM + `.most` baseline would fold into one
-  // invocation, but `--stable-baseline` is disabled while moc's bug is open.
-  // Flip this back to asserting the fold when `STABLE_BASELINE_DISABLED` goes.
-  test("moc 1.12+ EM keeps the classic path while --stable-baseline is off", async () => {
+  // Fixture pinned to moc 1.12.0: that build accepts `--stable-baseline` but lacks
+  // the fix, so the fold stays off and the classic path runs.
+  test("moc without the --stable-baseline fix keeps the classic path", async () => {
     const cwd = path.join(import.meta.dirname, "check-stable/migrations-chain");
     const result = await cli(["check-stable", "--verbose"], { cwd });
     expect(result.exitCode).toBe(0);
@@ -38,6 +38,46 @@ describe("check-stable", () => {
     expect(result.stdout).toMatch(/--stable-compatible/);
     expect(result.stdout).toMatch(/Generating stable types for/);
     expect(result.stdout).toMatch(/Stable compatibility check passed/);
+  });
+
+  // Regression: `check-limit` trims the chain back to DropB, whose input type still
+  // mentions `b`, while the baseline is already past DropB and no longer has `b`.
+  // moc 1.12.0-1.14.1 fail that valid upgrade from inside `moc --check
+  // --stable-baseline` with a bogus M0267 demanding `b`; the fix build passes it.
+  describe("baseline already past a trimmed migration", () => {
+    const makeTempFixture = useTempFixtures(
+      path.join(import.meta.dirname, "check-stable"),
+    );
+
+    test("folds and passes on a moc with the --stable-baseline fix", async () => {
+      const cwd = path.join(
+        import.meta.dirname,
+        "check-stable/trimmed-baseline",
+      );
+      const result = await cli(["check-stable", "--verbose"], { cwd });
+      expect(result.stdout).toMatch(/--stable-baseline/);
+      expect(result.stdout).not.toMatch(/--stable-compatible/);
+      expect(result.stdout).toMatch(/Stable compatibility check passed/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    // The workaround for every released moc: the 3-step path never had the bug.
+    test("passes on the classic path when moc lacks the fix", async () => {
+      const cwd = await makeTempFixture("trimmed-baseline");
+      const tomlPath = path.join(cwd, "mops.toml");
+      await writeFile(
+        tomlPath,
+        readFileSync(tomlPath, "utf-8").replace(
+          '"1.14.1-fix-stable-baseline"',
+          '"1.12.0"',
+        ),
+      );
+      const result = await cli(["check-stable", "--verbose"], { cwd });
+      expect(result.stdout).not.toMatch(/--stable-baseline/);
+      expect(result.stdout).toMatch(/--stable-compatible/);
+      expect(result.stdout).toMatch(/Stable compatibility check passed/);
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   test("rejects a .mo baseline in mops.toml", async () => {

--- a/cli/tests/check-stable/trimmed-baseline/deployed.most
+++ b/cli/tests/check-stable/trimmed-baseline/deployed.most
@@ -1,0 +1,11 @@
+// Version: 4.0.0
+{
+  "20250101_000000_AddA" :
+    (old : {b : Text; c : Bool}) -> {a : Nat; b : Text; c : Bool};
+  "20250201_000000_DropB" :
+    (old : {a : Nat; b : Text; c : Bool}) -> {a : Nat; c : Bool}
+}
+actor  {
+  stable a : Nat;
+  stable c : Bool
+};

--- a/cli/tests/check-stable/trimmed-baseline/migrations/20250101_000000_AddA.mo
+++ b/cli/tests/check-stable/trimmed-baseline/migrations/20250101_000000_AddA.mo
@@ -1,0 +1,9 @@
+module {
+  public func migration(old : { c : Bool; b : Text }) : {
+    a : Nat;
+    b : Text;
+    c : Bool;
+  } {
+    { old with a = 42 };
+  };
+};

--- a/cli/tests/check-stable/trimmed-baseline/migrations/20250201_000000_DropB.mo
+++ b/cli/tests/check-stable/trimmed-baseline/migrations/20250201_000000_DropB.mo
@@ -1,0 +1,8 @@
+module {
+  public func migration(old : { a : Nat; b : Text; c : Bool }) : {
+    a : Nat;
+    c : Bool;
+  } {
+    { a = old.a; c = old.c };
+  };
+};

--- a/cli/tests/check-stable/trimmed-baseline/mops.toml
+++ b/cli/tests/check-stable/trimmed-baseline/mops.toml
@@ -1,0 +1,15 @@
+[toolchain]
+moc = "1.14.1-fix-stable-baseline"
+
+[moc]
+args = ["--default-persistent-actors"]
+
+[canisters.backend]
+main = "src/main.mo"
+
+[canisters.backend.migrations]
+chain = "migrations"
+check-limit = 1
+
+[canisters.backend.check-stable]
+path = "deployed.most"

--- a/cli/tests/check-stable/trimmed-baseline/src/main.mo
+++ b/cli/tests/check-stable/trimmed-baseline/src/main.mo
@@ -1,0 +1,10 @@
+import Prim "mo:prim";
+
+actor {
+  let a : Nat;
+  let c : Bool;
+
+  public func check() : async () {
+    Prim.debugPrint(debug_show { a; c });
+  };
+};

--- a/docs/docs/cli/4-dev/05-mops-check-stable.md
+++ b/docs/docs/cli/4-dev/05-mops-check-stable.md
@@ -109,7 +109,7 @@ When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `m
 ## Diagnostics on moc 1.12.0+
 
 :::warning Temporarily disabled
-These improvements are turned off in the current release. `moc`'s `--stable-baseline` has a bug, so every `moc` pin runs the check the pre-1.12.0 way until `moc` ships a fix — the check still runs and still fails on an incompatible upgrade, but the diagnostics below are not in effect.
+These improvements are turned off for every released `moc`. With [`check-limit`](./08-mops-migrate.md#chain-trimming) trimming the chain, `moc --stable-baseline` rejects a baseline that is already past the trimmed migration — it demands a field that migration dropped and fails a valid upgrade with `M0267`. Until the fix ships, mops runs the check the pre-1.12.0 way: it still runs and still fails on a genuinely incompatible upgrade, but the diagnostics below are not in effect.
 :::
 
 On `moc` 1.12.0 or newer, two diagnostics improve for canisters that have `[migrations]` configured:


### PR DESCRIPTION
Regression coverage for the `moc --stable-baseline` bug that [#784](https://github.com/caffeinelabs/mops/pull/784) worked around by disabling the fold. The fix exists as a `moc` prerelease ([1.14.1-fix-stable-baseline](https://github.com/caffeinelabs/motoko/releases/tag/1.14.1-fix-stable-baseline)), so the test can pin it and assert the folded path is green — the coverage lands now instead of after the `moc` release.

Draft because it pins a prerelease `moc`. Ready to merge once the fix ships in a real release and the pin moves to it.

## The bug

`[migrations].check-limit` trims the chain to the most recent N migrations. When the deployed baseline is *already past* a trimmed-away migration, `moc --check --stable-baseline` reads that migration's input type, demands a field the migration itself dropped, and fails a valid upgrade:

```
src/main.mo:3.1-10.2: type error [M0267], initial actor requires field `b` of type
  Text; not found in the previous version — write a migration that produces it
```

The fixture is the minimal shape:

```
actor { a; c }
m1: {c; b} -> {a; b; c}      # adds a
m2: {a; b; c} -> {a; c}      # drops b
check-limit = 1              # trims the chain back to m2
```

With the baseline already past `m2`, `b` is legitimately gone — but `m2`'s input type still mentions it, and moc treats that as a missing field rather than an already-applied migration. Behavior across the matrix:

| baseline | fold, moc 1.12.0–1.14.1 | fold, fix build | 3-step path |
|---|---|---|---|
| `m2` still pending | pass | pass | pass |
| `m2` already applied | **false `M0267`** | pass | pass |

The bottom-left cell is the bug, and the right-hand column is why disabling the fold was a safe workaround — the three-step `--stable-types` + `--stable-compatible` path never had it. That also explains why the existing suite stayed green through the bug: every `[migrations]` fixture pinned a baseline that was still *behind* the trimmed migration, which is the passing row.

## Enabling the fold per build

The blanket `STABLE_BASELINE_DISABLED` boolean is replaced by an explicit set of `moc` builds known to carry the fix. A plain version floor cannot express this — the buggy `1.14.1` release sorts *above* the `1.14.1-fix-stable-baseline` prerelease under semver, so any floor that admits the fix build also admits the broken release.

```ts
const MOC_STABLE_BASELINE_FIXED_VERSIONS = new Set([
  "1.14.1-fix-stable-baseline",
]);
```

Nothing changes for users: no released `moc` is in the set, so every real pin still takes the three-step path. When the fix ships, this collapses to a version floor and the set disappears.

## Verified the test actually catches it

Adding `"1.14.1"` to the set — pretending the broken release carried the fix — makes the new test fail on the false `M0267`, and removing it makes it pass. A test that only ever passes would not be worth committing.

## What is unchanged

- No changelog entry: no released `moc` folds, so there is no user-visible behavior change. The shipped 3.1.0 entry describing the disable stays as-is.
- The `moc` download path already points at `caffeinelabs/motoko`, so the prerelease pin resolves with no toolchain changes.
- The three-step path, `-A=M0254` suppression, and the `check-limit` pending-migration diagnostic are all untouched.

## Follow-up

Once the fix is in a released `moc`: swap the set for a version floor, re-point this fixture, flip the two "lacks the fix" tests back to asserting the fold, and drop the temporarily-disabled note from `05-mops-check-stable.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
