### PR TITLE
fix(cli): surface why `mops self update` failed

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
+- `mops self update` now shows why an update failed. The install ran under npm's `--silent`, which suppresses npm's own error output, so any failure — a permission error on the global prefix, an `engines` mismatch, a cached bad tarball — surfaced as a bare `Failed to update.` with nothing to act on. It now runs with `--loglevel=error`.
 
 ## 3.1.0
 - Temporarily disabled `--stable-baseline` in `mops check` and `mops check-stable` due to a `moc` bug. Upgrade compatibility is still checked, but the moc 1.12.0+ diagnostics are off until moc ships a fix.

--- a/cli/commands/self.ts
+++ b/cli/commands/self.ts
@@ -96,7 +96,9 @@ export async function update({ major = false } = {}) {
     console.log("Updating to version: " + chalk.green(latest));
 
     let pm = detectPackageManager();
-    let npmArgs = pm === "npm" ? ["--no-fund", "--silent"] : [];
+    // Not `--silent`: that suppresses npm's own error output too, leaving
+    // "Failed to update." as the only clue to why.
+    let npmArgs = pm === "npm" ? ["--no-fund", "--loglevel=error"] : [];
 
     await new Promise<void>((resolve, reject) => {
       let proc = child_process.spawn(


### PR DESCRIPTION
`mops self update` ran the install under npm's `--silent`. That flag suppresses npm's *own error output*, not just its progress noise, so any failure — a permission error on the global prefix, an `engines` mismatch, a cached bad tarball — reached the user as three words with nothing to act on:

```
% mops self update
Current version: 2.19.2
Updating to version: 3.1.0
Failed to update.
```

That is the entire output. `stdio` is `'inherit'`, so npm's diagnosis was being printed to a stream nobody suppressed — npm simply never wrote it.

## Before / After

Same failing install, with `--loglevel=error` in place of `--silent`:

```
npm error code TAR_BAD_ARCHIVE
npm error TAR_BAD_ARCHIVE: Unrecognized archive format
npm error A complete log of this run can be found in: ~/.npm/_logs/2026-08-24T11_25_37_266Z-debug-0.log
Failed to update.
```

`--loglevel=error` rather than dropping the flag outright: on success it still prints only `added 4 packages in 1s`, and on failure it drops the `npm warn tar TAR_ENTRY_INVALID checksum failure` spam that precedes the real error.

## What is unchanged

- **The release artifacts are fine.** `tags/latest` returns `3.1.0` and `/versions/3.1.0.tgz` serves 2,394,985 bytes whose sha256 matches `cli-releases/versions/3.1.0.tgz` exactly, identical across ten consecutive fetches. Upgrading 2.19.2 → 3.1.0 in place works and correctly drops the stale `moc-wrapper` bin link. This PR does not change what is served.
- **The pnpm branch keeps its empty flag list.** The reported failure is on npm, and `--loglevel` is not the same flag on pnpm.
- **`self uninstall` keeps its `--silent`.** It is fire-and-forget — the exit code is never checked — so surfacing output there is a separate change.
- **No test.** The spawn is not testable in-process, which is why `self-update.test.ts` covers only `classifySelfUpdate`. A one-flag change did not seem worth restructuring that for.

## Follow-up worth flagging

`detectPackageManager` decides between npm and pnpm by testing whether `which mops` contains `pnpm/`. A user who installed with yarn or bun gets `npm add -g`, which installs to npm's global prefix while the `mops` on `PATH` stays the old binary — a silent no-op that reports `Success`. Out of scope here; the reported bug is the invisible error.
