### PR TITLE
docs(skill): comment out check-wasm/check-deploy in the minimal `mops.toml`

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -35,7 +35,7 @@ main = "src/backend/main.mo"
 
 [canisters.backend.migrations]
 chain = "src/backend/migrations"
-check-limit = 10   # optional — speeds up `mops check` when the chain gets long
+# check-limit = 10   # optional — speeds up `mops check` when the chain gets long
 
 [canisters.backend.check-stable]
 path = "deployed/backend.most"

--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -43,8 +43,8 @@ path = "deployed/backend.most"
 [build]
 outputDir = "src/backend/dist"
 args = ["--release"]
-check-wasm = true    # optional: analyze final Wasm complexity
-check-deploy = true  # optional: verify fresh PocketIC installation after build
+# check-wasm = true    # optional: analyze final Wasm complexity
+# check-deploy = true  # optional: verify fresh PocketIC installation after build
 
 # Opt-in Wasm optimization (Binaryen wasm-opt) for build + bench
 [optimize]


### PR DESCRIPTION
The "Minimal `mops.toml`" starter in the `mops-cli` skill shipped `check-wasm = true` and `check-deploy = true` as active settings. Anyone copy-pasting it into a new project silently opted into a PocketIC install on every `mops build` — a real runtime and CI cost — because the `# optional` trailing comment reads as a description of the flag, not a signal that the example turns it on. The neighbouring `[optimize]` block already models the right treatment: opt-in settings are shown commented out with their defaults.

Every setting the example itself labels `# optional` is now commented out, matching `[optimize]` — the two build validations plus `check-limit`, which had the same "labelled optional, actually on" shape.

**Before**

```toml
[canisters.backend.migrations]
chain = "src/backend/migrations"
check-limit = 10   # optional — speeds up `mops check` when the chain gets long

[build]
outputDir = "src/backend/dist"
args = ["--release"]
check-wasm = true    # optional: analyze final Wasm complexity
check-deploy = true  # optional: verify fresh PocketIC installation after build
```

**After**

```toml
[canisters.backend.migrations]
chain = "src/backend/migrations"
# check-limit = 10   # optional — speeds up `mops check` when the chain gets long

[build]
outputDir = "src/backend/dist"
args = ["--release"]
# check-wasm = true    # optional: analyze final Wasm complexity
# check-deploy = true  # optional: verify fresh PocketIC installation after build
```

## What is unchanged

The `check-wasm` / `check-deploy` examples in [`docs/docs/09-mops.toml.md`](docs/docs/09-mops.toml.md) and [`docs/docs/cli/4-dev/03-mops-build.md`](docs/docs/cli/4-dev/03-mops-build.md) stay active — those sit under a heading that documents the flags themselves, where showing the setting enabled is the point. Only the starter config a reader is meant to copy wholesale changes.

Closes [#793](https://github.com/caffeinelabs/mops/issues/793), reported from the downstream sync in [dfinity/icskills#358](https://github.com/dfinity/icskills/pull/358).