### PR TITLE
feat(cli): re-enable --stable-baseline on moc 1.15.0+

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -128,7 +128,7 @@ Adding a package that is already declared in the other section **moves** it rath
 
 Primary correctness command — runs moc check, then check-stable (if configured), then lint (if lintoko is in toolchain).
 
-On moc 1.12.0+, canisters with `[migrations]` get stricter upgrade diagnostics: a field the initial actor requires that no migration produces fails as an `M0267` error instead of only warning (`M0254`), and compat errors carry a source location. **Temporarily disabled** — `moc --stable-baseline` is buggy, so every pin runs the pre-1.12.0 check. Older moc pins and canisters without `[migrations]` are unaffected either way.
+On moc 1.15.0+, canisters with `[migrations]` get stricter upgrade diagnostics: a field the initial actor requires that no migration produces fails as an `M0267` error instead of only warning (`M0254`), and compat errors carry a source location. Older moc pins and canisters without `[migrations]` are unaffected either way.
 
 The `check-stable` baseline is always a `.most` file — as `[canisters.<name>.check-stable].path` or as the `mops check-stable <baseline.most>` argument. A `.mo` source is rejected. See [`mops deployed`](#mops-deployed) for where the baseline comes from — that differs between a fresh project and an already-deployed canister.
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
+- `mops check` and `mops check-stable` re-enable the `--stable-baseline` fast path on `moc` 1.15.0+, which fixes the trimmed-baseline bug (`M0267`) that kept the fold disabled since 3.1.0. Upgrades check in one `moc --check` again and the moc 1.12.0+ diagnostics return. On 1.15.0+, `moc` also validates the migration directory against the migration history in the baseline and treats a deleted, edited, or backdated migration as an `M0268` error (by default; demote with `-W=M0268`, silence with `-A=M0268`) — pin at least 1.15.0 before relying on the fold.
 - `mops self update` now shows why an update failed. The install ran under npm's `--silent`, which suppresses npm's own error output, so any failure — a permission error on the global prefix, an `engines` mismatch, a cached bad tarball — surfaced as a bare `Failed to update.` with nothing to act on. It now runs with `--loglevel=error`.
 
 ## 3.1.0

--- a/cli/commands/check-stable.ts
+++ b/cli/commands/check-stable.ts
@@ -35,16 +35,8 @@ function hasEnhancedMigrationArg(args: string[]): boolean {
   );
 }
 
-// TEMPORARY: `moc --stable-baseline` is buggy, so no pin folds the upgrade check
-// into `moc --check` — everything takes the 3-invocation path. Drop this constant
-// and the guard below once moc ships the fix.
-const STABLE_BASELINE_DISABLED = true;
-
-/** moc 1.12.0+: one `moc --check --stable-baseline` instead of 3 invocations. */
+/** moc 1.15.0+: one `moc --check --stable-baseline` instead of 3 invocations. */
 export function canUseStableBaselineCheck(canisterArgs: string[]): boolean {
-  if (STABLE_BASELINE_DISABLED) {
-    return false;
-  }
   return supportsStableBaselineCheck() && hasEnhancedMigrationArg(canisterArgs);
 }
 
@@ -334,7 +326,7 @@ export async function runStableCheck(
     cliError(`File not found: ${baselineMost}`);
   }
 
-  // moc 1.12.0+ → one --check, no scratch dir.
+  // moc 1.15.0+ → one --check, no scratch dir.
   if (canUseStableBaselineCheck(canisterArgs)) {
     await runFoldedStableCheck({
       canisterMain,

--- a/cli/helpers/get-moc-version.ts
+++ b/cli/helpers/get-moc-version.ts
@@ -17,8 +17,10 @@ export function getMocVersion(): string {
   return version;
 }
 
-/** First moc that runs the upgrade check inside `moc --check --stable-baseline`. */
-export const MOC_STABLE_BASELINE_MIN_VERSION = "1.12.0";
+// First moc where `--stable-baseline` gets the upgrade check right: earlier
+// builds that accept the flag mishandle a baseline already past a migration
+// `check-limit` trimmed away, failing valid upgrades with a bogus M0267.
+export const MOC_STABLE_BASELINE_MIN_VERSION = "1.15.0";
 
 export function supportsStableBaselineCheck(): boolean {
   const version = getMocSemVer();

--- a/cli/tests/check-stable.test.ts
+++ b/cli/tests/check-stable.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "@jest/globals";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import path from "path";
-import { cli, cliSnapshot } from "./helpers";
+import { cli, cliSnapshot, useTempFixtures } from "./helpers";
 
 describe("check-stable", () => {
   test("compatible upgrade", async () => {
@@ -27,10 +28,9 @@ describe("check-stable", () => {
     expect(result.stdout).toMatch(/Stable compatibility check passed/);
   });
 
-  // Fixture pinned to moc 1.12.0 — EM + `.most` baseline would fold into one
-  // invocation, but `--stable-baseline` is disabled while moc's bug is open.
-  // Flip this back to asserting the fold when `STABLE_BASELINE_DISABLED` goes.
-  test("moc 1.12+ EM keeps the classic path while --stable-baseline is off", async () => {
+  // Fixture pinned to moc 1.12.0: that build accepts `--stable-baseline` but lacks
+  // the fix, so the fold stays off and the classic path runs.
+  test("moc without the --stable-baseline fix keeps the classic path", async () => {
     const cwd = path.join(import.meta.dirname, "check-stable/migrations-chain");
     const result = await cli(["check-stable", "--verbose"], { cwd });
     expect(result.exitCode).toBe(0);
@@ -38,6 +38,43 @@ describe("check-stable", () => {
     expect(result.stdout).toMatch(/--stable-compatible/);
     expect(result.stdout).toMatch(/Generating stable types for/);
     expect(result.stdout).toMatch(/Stable compatibility check passed/);
+  });
+
+  // Regression: `check-limit` trims the chain back to DropB, whose input type still
+  // mentions `b`, while the baseline is already past DropB and no longer has `b`.
+  // moc 1.12.0-1.14.x fail that valid upgrade from inside `moc --check
+  // --stable-baseline` with a bogus M0267 demanding `b`; moc 1.15.0 passes it.
+  describe("baseline already past a trimmed migration", () => {
+    const makeTempFixture = useTempFixtures(
+      path.join(import.meta.dirname, "check-stable"),
+    );
+
+    test("folds and passes on moc 1.15.0+", async () => {
+      const cwd = path.join(
+        import.meta.dirname,
+        "check-stable/trimmed-baseline",
+      );
+      const result = await cli(["check-stable", "--verbose"], { cwd });
+      expect(result.stdout).toMatch(/--stable-baseline/);
+      expect(result.stdout).not.toMatch(/--stable-compatible/);
+      expect(result.stdout).toMatch(/Stable compatibility check passed/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    // The 3-step fallback for earlier moc never had the bug.
+    test("passes on the classic path when moc lacks the fix", async () => {
+      const cwd = await makeTempFixture("trimmed-baseline");
+      const tomlPath = path.join(cwd, "mops.toml");
+      await writeFile(
+        tomlPath,
+        readFileSync(tomlPath, "utf-8").replace('"1.15.0"', '"1.12.0"'),
+      );
+      const result = await cli(["check-stable", "--verbose"], { cwd });
+      expect(result.stdout).not.toMatch(/--stable-baseline/);
+      expect(result.stdout).toMatch(/--stable-compatible/);
+      expect(result.stdout).toMatch(/Stable compatibility check passed/);
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   test("rejects a .mo baseline in mops.toml", async () => {

--- a/cli/tests/check-stable/trimmed-baseline/deployed.most
+++ b/cli/tests/check-stable/trimmed-baseline/deployed.most
@@ -1,0 +1,11 @@
+// Version: 4.0.0
+{
+  "20250101_000000_AddA" :
+    (old : {b : Text; c : Bool}) -> {a : Nat; b : Text; c : Bool};
+  "20250201_000000_DropB" :
+    (old : {a : Nat; b : Text; c : Bool}) -> {a : Nat; c : Bool}
+}
+actor  {
+  stable a : Nat;
+  stable c : Bool
+};

--- a/cli/tests/check-stable/trimmed-baseline/migrations/20250101_000000_AddA.mo
+++ b/cli/tests/check-stable/trimmed-baseline/migrations/20250101_000000_AddA.mo
@@ -1,0 +1,9 @@
+module {
+  public func migration(old : { c : Bool; b : Text }) : {
+    a : Nat;
+    b : Text;
+    c : Bool;
+  } {
+    { old with a = 42 };
+  };
+};

--- a/cli/tests/check-stable/trimmed-baseline/migrations/20250201_000000_DropB.mo
+++ b/cli/tests/check-stable/trimmed-baseline/migrations/20250201_000000_DropB.mo
@@ -1,0 +1,8 @@
+module {
+  public func migration(old : { a : Nat; b : Text; c : Bool }) : {
+    a : Nat;
+    c : Bool;
+  } {
+    { a = old.a; c = old.c };
+  };
+};

--- a/cli/tests/check-stable/trimmed-baseline/mops.toml
+++ b/cli/tests/check-stable/trimmed-baseline/mops.toml
@@ -1,0 +1,15 @@
+[toolchain]
+moc = "1.15.0"
+
+[moc]
+args = ["--default-persistent-actors"]
+
+[canisters.backend]
+main = "src/main.mo"
+
+[canisters.backend.migrations]
+chain = "migrations"
+check-limit = 1
+
+[canisters.backend.check-stable]
+path = "deployed.most"

--- a/cli/tests/check-stable/trimmed-baseline/src/main.mo
+++ b/cli/tests/check-stable/trimmed-baseline/src/main.mo
@@ -1,0 +1,10 @@
+import Prim "mo:prim";
+
+actor {
+  let a : Nat;
+  let c : Bool;
+
+  public func check() : async () {
+    Prim.debugPrint(debug_show { a; c });
+  };
+};

--- a/cli/tests/check.test.ts
+++ b/cli/tests/check.test.ts
@@ -115,7 +115,7 @@ describe("check", () => {
 
   // Fixture pinned to moc 1.12.0: folding needs --enhanced-migration, so a
   // non-EM canister keeps the classic path even on a moc that supports it.
-  // (`--stable-baseline` is disabled outright for now, so this also holds for EM.)
+  // (This pin is below the 1.15.0 fold floor, so it holds for EM as well.)
   test("deployed: non-EM canister does not fold into --stable-baseline", async () => {
     const cwd = path.join(import.meta.dirname, "check/deployed-compatible");
     const result = await cli(["check", "--verbose"], { cwd });

--- a/docs/docs/cli/4-dev/04-mops-check.md
+++ b/docs/docs/cli/4-dev/04-mops-check.md
@@ -134,7 +134,7 @@ If the file at `path` doesn't exist, the check fails with an error. For initial 
 actor { };
 ```
 
-On `moc` 1.12.0+, canisters with `[migrations]` configured and a `.most` baseline get better upgrade diagnostics — currently disabled while a `moc` bug is open, see [diagnostics on moc 1.12.0+](./05-mops-check-stable.md#diagnostics-on-moc-1120).
+On `moc` 1.15.0+, canisters with `[migrations]` configured and a `.most` baseline get better upgrade diagnostics, see [diagnostics on moc 1.15.0+](./05-mops-check-stable.md#diagnostics-on-moc-1150).
 
 For more details, see [`mops check-stable`](./05-mops-check-stable.md).
 

--- a/docs/docs/cli/4-dev/05-mops-check-stable.md
+++ b/docs/docs/cli/4-dev/05-mops-check-stable.md
@@ -13,7 +13,7 @@ mops check-stable [args...]
 
 Verifies that an upgrade from an old actor to the current canister entrypoint is safe — i.e., that stable variable signatures are compatible. This prevents `Memory-incompatible program upgrade` traps at deploy time.
 
-The baseline is always a committed `.most` file — see [Getting a baseline](#getting-a-baseline). The command handles the rest internally: generating the current `.most` stable type signature, comparing it against the baseline, and cleaning up intermediate files. On `moc` 1.12.0+ some [diagnostics improve](#diagnostics-on-moc-1120).
+The baseline is always a committed `.most` file — see [Getting a baseline](#getting-a-baseline). The command handles the rest internally: generating the current `.most` stable type signature, comparing it against the baseline, and cleaning up intermediate files. On `moc` 1.15.0+ some [diagnostics improve](#diagnostics-on-moc-1150).
 
 When checking canisters, per-canister `[canisters.<name>].args` from `mops.toml` are applied alongside global `[moc].args`.
 
@@ -100,19 +100,15 @@ Require an up-to-date [`mops.lock`](../../10-mops.lock.md) and never write it �
 
 When `[canisters.<name>.migrations].check-limit` is set, `mops check-stable` compares the deployed `.most` baseline against the local chain after the compatibility check. If more migrations are pending than `check-limit` allows, mops reports a diagnostic naming the latest pending file to fold into. If compat already failed, this replaces the misleading `moc` error (trimming started from the wrong state). If compat passed anyway, it is shown as a warning.
 
-On `moc` 1.12.0+ this diagnostic can also replace type errors from the same run. The command still exits non-zero; fold the pending migrations (or pass `--no-check-limit`) to see them. (Currently inactive — see [diagnostics on moc 1.12.0+](#diagnostics-on-moc-1120).)
+On `moc` 1.15.0+ this diagnostic can also replace type errors from the same run. The command still exits non-zero; fold the pending migrations (or pass `--no-check-limit`) to see them.
 
 ## Enhanced migration support
 
 When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops check-stable` automatically injects the `--enhanced-migration` flag when generating stable type signatures.
 
-## Diagnostics on moc 1.12.0+
+## Diagnostics on moc 1.15.0+
 
-:::warning Temporarily disabled
-These improvements are turned off in the current release. `moc`'s `--stable-baseline` has a bug, so every `moc` pin runs the check the pre-1.12.0 way until `moc` ships a fix — the check still runs and still fails on an incompatible upgrade, but the diagnostics below are not in effect.
-:::
-
-On `moc` 1.12.0 or newer, two diagnostics improve for canisters that have `[migrations]` configured:
+On `moc` 1.15.0 or newer, two diagnostics improve for canisters that have `[migrations]` configured:
 
 - A field the initial actor requires that no migration produces now **fails** the check (`M0267`) instead of only warning (`M0254`). If a forgotten migration used to slip through as a warning, expect it to be an error now. Fields the baseline already provides with a compatible type stay a warning.
 - Compatibility errors point at your source — `src/main.mo:3.1-11.2` — instead of `(unknown location)`.

--- a/docs/docs/cli/4-dev/08-mops-migrate.md
+++ b/docs/docs/cli/4-dev/08-mops-migrate.md
@@ -93,6 +93,6 @@ The limits count the full virtual chain (frozen + pending next migration). This 
 
 Already-applied migrations are skipped at runtime by the Motoko RTS, so trimming is safe. When trimming is active, M0254 warnings are automatically suppressed.
 
-On moc 1.12.0+ that suppression covers fields the deployed `.most` baseline already provides — the normal trimming case. A field that the baseline does not provide and no migration in the chain produces fails as an M0267 error instead of warning. This is currently disabled while a `moc` bug is open, so every pin warns — see [diagnostics on moc 1.12.0+](./05-mops-check-stable.md#diagnostics-on-moc-1120).
+On moc 1.15.0+ that suppression covers fields the deployed `.most` baseline already provides — the normal trimming case. A field that the baseline does not provide and no migration in the chain produces fails as an M0267 error instead of warning — see [diagnostics on moc 1.15.0+](./05-mops-check-stable.md#diagnostics-on-moc-1150).
 
 When `check-limit` is set, `mops check-stable` (and the stable check inside `mops check`) compares the deployed `.most` baseline against the local chain after the compatibility check. If more migrations are pending than `check-limit` allows, mops reports a diagnostic suggesting to fold all changes into the latest pending migration. If compat already failed, this replaces the misleading `moc` error; if compat passed anyway, it is shown as a warning. Only runs when `check-limit` is configured.


### PR DESCRIPTION
## Why

moc 1.15.0 ships the fix for the bug that made PR #784 necessary. The M0254/M0267 check now resumes from the migrations the baseline records as already applied, instead of replaying the whole chain. A baseline already past a `check-limit`-trimmed migration no longer trips a false M0267 demanding a field that migration dropped.

This re-enables the `--stable-baseline` fold on `moc >= 1.15.0`. `mops check` and `mops check-stable` run one `moc --check` again, and the upgraded diagnostics return where the pin supports them.

## Scope

`cli/helpers/get-moc-version.ts` moves `MOC_STABLE_BASELINE_MIN_VERSION` from `1.12.0` to `1.15.0`. Every earlier build that accepts the flag still has the bug, so the floor is the whole gate.

`cli/commands/check-stable.ts` removes the temporary `STABLE_BASELINE_DISABLED` constant and its guard. `canUseStableBaselineCheck` is `supportsStableBaselineCheck() && hasEnhancedMigrationArg(...)` again.

Tests. The new `trimmed-baseline` fixture places a baseline after a trimmed migration. The fold passes on 1.15.0 and falls back to the classic path on 1.12.0.

Docs. `docs/docs/cli/4-dev/{04-mops-check,05-mops-check-stable,08-mops-migrate}.md` and `.agents/skills/mops-cli/SKILL.md` drop the temporarily-disabled note and move the diagnostic threshold to 1.15.0+. `cli/CHANGELOG.md` gets the `## Next` entry.

Out of scope. The 2.x `versioned_docs` snapshot stays frozen. The per-build fixed-version set from the draft regression coverage is deleted. No released `moc` now accepts the flag but lacks the fix, so a single floor says everything.

## Tradeoffs

`MOC_STABLE_BASELINE_MIN_VERSION` keeps its name but now means the first `moc` where the fold is safe, not the first `moc` that accepts the flag. Only the fold gate consumes it, so the shift is safe.

moc 1.15.0 also enables M0268. It treats a deleted, edited, or backdated migration as an error by default. That surfaces only for migration sets the baseline says were already applied, so it is the right call, but it is new on this path.

## Blast Radius

Any project pinned to `moc >= 1.15.0` with `[migrations]` gets the single-invocation check and the stricter diagnostics back. Older pins and projects without `[migrations]` run unchanged. The mops repo itself pins `moc 0.14.14`, so the fold stays off here.

## Verification

`cli` typecheck, prettier, and eslint pass. `npm test -- check-stable` is green: 18 passed, 3 snapshots. The new tests assert the fold on 1.15.0 (`--stable-baseline` present, `--stable-compatible` absent) and the classic path on 1.12.0. I proved the regression test has teeth by forcing the fold on for the buggy 1.12.0 build and watching the false M0267: `initial actor requires field 'b' ... not found in the previous version`.

Made with [Cursor](https://cursor.com)