### PR TITLE
review: pin AI review model to cursor-grok-4.6-high-fast

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -149,7 +149,7 @@ jobs:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_TOKEN }}
           # Pinned frontier model; the account default ("Auto") routes to cheaper
           # models that produce shallow reviews.
-          REVIEW_MODEL: grok-4.6
+          REVIEW_MODEL: cursor-grok-4.6-high-fast
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## What

Single-line bugfix: the Cursor AI PR review workflow passed the **unsupported model id** `grok-4.6`, so the review errored and posted REVIEW_ERROR. Repin to the supported frontier id `cursor-grok-4.6-high-fast`, matching skills-internal #277 / app#8426.

- `REVIEW_MODEL: grok-4.6` → `cursor-grok-4.6-high-fast`
- Everything else unchanged.

Verified with `actionlint .github/workflows/ai-pr-review.yml` (0 errors).