### PR TITLE
docs(skill): bump stale toolchain pins in mops-cli skill and docs

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -20,12 +20,12 @@ Opinionated guide for Motoko projects. Covers project config, dependency managem
 
 ```toml
 [toolchain]
-moc = "1.7.0"
-lintoko = "0.10.0"
+moc = "1.15.1"
+lintoko = "0.11.0"
 pocket-ic = "15.0.0"  # required for replica tests / benchmarks / --check-deploy
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
 args = ["--default-persistent-actors", "-W=M0223,M0236,M0237"]
@@ -189,9 +189,9 @@ mops generate candid backend -o <path>   # single canister, ad-hoc path
 ### `mops toolchain`
 
 ```bash
-mops toolchain use moc 1.7.0         # pin specific version
+mops toolchain use moc 1.15.1        # pin specific version
 mops toolchain use moc latest        # pin latest version (non-interactive)
-mops toolchain use lintoko 0.10.0    # pin specific version
+mops toolchain use lintoko 0.11.0    # pin specific version
 mops toolchain use pocket-ic 15.0.0  # pin for replica tests / benchmarks / --check-deploy
 mops toolchain use wasm-opt 131      # Binaryen for [optimize] (or `latest`)
 mops toolchain update moc            # update to latest (requires existing [toolchain] entry)

--- a/docs/docs/09-mops.toml.md
+++ b/docs/docs/09-mops.toml.md
@@ -61,10 +61,10 @@ See [toolchain management](./cli/5-toolchain/01-toolchain-overview.md) page for 
 
 | Field                | Description                                      |
 | -------------------- | ------------------------------------------------ |
-| moc                  | Motoko compiler version (e.g. `1.0.0`) or file path (e.g. `./tools/moc`, `/usr/local/bin/moc`)   |
+| moc                  | Motoko compiler version (e.g. `1.15.1`) or file path (e.g. `./tools/moc`, `/usr/local/bin/moc`)   |
 | wasmtime             | WASM runtime version (e.g. `41.0.0`) or file path used to run [tests](./cli/4-dev/01-mops-test.md#--mode) in `wasi` mode   |
 | pocket-ic            | [PocketIC](https://github.com/dfinity/pocketic) replica version (e.g. `15.0.0`) or file path, used to run [benchmarks](./cli/4-dev/02-mops-bench.md) and [replica tests](./cli/4-dev/01-mops-test.md#replica-tests). Required when those commands (or `--check-deploy`) run — there is no default. Versions below `9.0.0` are no longer supported. See [`pocket-ic` versions](./cli/5-toolchain/01-toolchain-overview.md#pocket-ic-versions)   |
-| lintoko              | Linter version (e.g. `0.7.0`) or file path for Motoko linting   |
+| lintoko              | Linter version (e.g. `0.11.0`) or file path for Motoko linting   |
 | wasm-opt             | Binaryen version (e.g. `131`) or file path used for `[optimize]` post-build Wasm optimization   |
 
 File paths must start with `/`, `./`, or `../`.

--- a/docs/docs/cli/5-toolchain/01-toolchain-overview.md
+++ b/docs/docs/cli/5-toolchain/01-toolchain-overview.md
@@ -22,10 +22,10 @@ When you run `mops install` command, Mops will install the specified version of 
 
 You can use [`mops toolchain use`](./03-mops-toolchain-use.md) command to install specific tool version and update `mops.toml` file.
 ```
-mops toolchain use moc 1.0.0
+mops toolchain use moc 1.15.1
 mops toolchain use wasmtime 41.0.0
 mops toolchain use pocket-ic 15.0.0
-mops toolchain use lintoko 0.7.0
+mops toolchain use lintoko 0.11.0
 mops toolchain use wasm-opt 131
 ```
 
@@ -37,9 +37,9 @@ You can manually edit `mops.toml` file to specify exact versions of each tool.
 
 ```toml
 [toolchain]
-moc = "1.0.0"
+moc = "1.15.1"
 wasmtime = "41.0.0"
-lintoko = "0.7.0"
+lintoko = "0.11.0"
 pocket-ic = "15.0.0"
 wasm-opt = "131"
 ```

--- a/docs/docs/cli/5-toolchain/03-mops-toolchain-use.md
+++ b/docs/docs/cli/5-toolchain/03-mops-toolchain-use.md
@@ -15,10 +15,10 @@ mops toolchain use <tool> [version]
 
 Install specific tool version
 ```
-mops toolchain use moc 1.0.0
+mops toolchain use moc 1.15.1
 mops toolchain use wasmtime 41.0.0
 mops toolchain use pocket-ic 15.0.0
-mops toolchain use lintoko 0.7.0
+mops toolchain use lintoko 0.11.0
 ```
 
 You can specify `latest` as version to install the latest available version.


### PR DESCRIPTION
## Why

The `mops-cli` skill's minimal `mops.toml` pinned `moc 1.7.0` and `lintoko 0.10.0`, years behind current releases. The same skill documents diagnostics that only fire on `moc 1.15.0+`, so an agent copying the starter config silently opted out of the behavior the doc just described. This closes caffeinelabs/mops#807.

## Scope

Bumped version strings only, in four files.

- `.agents/skills/mops-cli/SKILL.md`: minimal `[toolchain]` block and the `mops toolchain use` examples.
- `docs/docs/cli/5-toolchain/03-mops-toolchain-use.md`: example command block.
- `docs/docs/cli/5-toolchain/01-toolchain-overview.md`: both the command block and the `[toolchain]` TOML block.
- `docs/docs/09-mops.toml.md`: `moc` and `lintoko` example versions in the `[toolchain]` reference table.

Pins are now: `moc 1.15.1`, `lintoko 0.11.0`, `core 2.6.1`. `pocket-ic 15.0.0`, `wasmtime 41.0.0`, and `wasm-opt 131` were already current and are unchanged.

## Tradeoffs

Concrete pins rather than `moc latest`. A fixed pin gives reproducible guidance for a starter project, and `latest` in a written example would drift out of date and back into the same complaint.

Out of scope on purpose: `docs/versioned_docs/` (frozen 2.x snapshot), CLI test fixtures pinned to old `moc` to exercise legacy paths, and the repository root `mops.toml` (real config, not an example).

## Blast Radius

This is documentation-only. No code, config, or CI behavior changes. Downstream copies of the skill that mirror upstream 1:1, such as dfinity/icskills, will pick up corrected guidance on their next sync.

## Verification

New versions confirmed against upstream releases: `moc 1.15.1` (dfinity/motoko latest, 2026-09-02), `lintoko 0.11.0` (caffeinelabs/lintoko latest tag), `core 2.6.1` (caffeinelabs/motoko-core latest tag). A grep of `SKILL.md` and `docs/docs` after the edit confirmed no old pins (`moc 1.7.0`, `lintoko 0.10.0`, `core 2.5.0`, `moc 1.0.0`, `lintoko 0.7.0`) remain. Diff is 13 insertions, 13 deletions across four markdown files.

Made with [Cursor](https://cursor.com)